### PR TITLE
Remove horizontal overflow from task creation paper form

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -702,6 +702,7 @@ input:focus{
   flex: 1;
   max-height: calc(100% - 40px);
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* Ensure inputs/selects fill the widget */


### PR DESCRIPTION
### Motivation
- Prevent the horizontal scrollbar inside the task creation paper form while preserving the existing vertical scrolling so the form remains usable on narrow viewports.

### Description
- Add `overflow-x: hidden` to `#create-task-widget .paper-form` in `public/css/main.css` while leaving `overflow-y: auto` intact.

### Testing
- Confirmed the new rule is present in `public/css/main.css` and attempted to start the app for visual verification, but the server failed to start due to a MongoDB DNS resolution error (`querySrv ENOTFOUND _mongodb._tcp.cluster0.fyexz.mongodb.net`), preventing in-browser validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa939505c8326a1d511dba94ce4d1)