### PR TITLE
Fix login regression by hardening auth response handling and session cleanup

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,10 +1,30 @@
 // Auth and tasks behavior for Donezo
+
+async function parseApiResponse(response) {
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+        return response.json();
+    }
+
+    const text = await response.text();
+    return { error: text || "Unexpected server response" };
+}
+
 document.addEventListener("DOMContentLoaded", () => {
     console.log("DOM Fully Loaded - JavaScript Running");
 
     // Page flags let us adjust behavior for standalone login/register views
     const isLoginPage = document.body.classList.contains("login-page");
     const isRegisterPage = document.body.classList.contains("register-page");
+    const currentPath = window.location.pathname;
+    const protectedPaths = new Set([
+        "/dashboard.html",
+        "/calendar-page.html",
+        "/profile-page.html",
+        "/settings-page.html",
+        "/feedback-page.html"
+    ]);
+    const isProtectedPage = protectedPaths.has(currentPath);
 
     // Registration handler (used on register.html)
     const registerForm = document.getElementById("registerForm");
@@ -32,20 +52,26 @@ document.addEventListener("DOMContentLoaded", () => {
 
            
 
-            const response = await fetch("/register", {
-                method: "POST",
-                headers: { "Content-Type": "application/json"},
-                body: JSON.stringify({ firstName, lastName, email, password })
-            });
+            try {
+                const response = await fetch("/register", {
+                    credentials: "include",
+                    method: "POST",
+                    headers: { "Content-Type": "application/json"},
+                    body: JSON.stringify({ firstName, lastName, email, password })
+                });
 
-            const data = await response.json();
+                const data = await parseApiResponse(response);
 
-            // Check if registration went alright
-            if (response.ok) {
-                alert("Registration successful! Please log in.");
-                window.location.href = "/login.html";
-            } else {
-                alert("Registration failed: " + data.error);
+                // Check if registration went alright
+                if (response.ok) {
+                    alert("Registration successful! Please log in.");
+                    window.location.href = "/login.html";
+                } else {
+                    alert("Registration failed: " + (data.error || "Unknown error"));
+                }
+            } catch (error) {
+                console.error("Registration request failed:", error);
+                alert("Registration failed due to a network/server issue.");
             }
         });
     }
@@ -60,21 +86,26 @@ document.addEventListener("DOMContentLoaded", () => {
             const password = document.getElementById("loginPassword").value;
             const rememberMe = document.getElementById("rememberMe")?.checked || false;
 
-            const response = await fetch("/login", {
-                credentials: "same-origin",
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ email, password, rememberMe })
-            });
-        
-            const data = await response.json();
-        
-            if (response.ok) {
-                alert("Login successful!");
-                // Auth pages should move you to the dashboard once logged in
-                window.location.href = "/dashboard.html";
-            } else {
-                alert("Login failed: " + data.error);
+            try {
+                const response = await fetch("/login", {
+                    credentials: "include",
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ email, password, rememberMe })
+                });
+            
+                const data = await parseApiResponse(response);
+            
+                if (response.ok) {
+                    alert("Login successful!");
+                    // Auth pages should move you to the dashboard once logged in
+                    window.location.href = "/dashboard.html";
+                } else {
+                    alert("Login failed: " + (data.error || "Unknown error"));
+                }
+            } catch (error) {
+                console.error("Login request failed:", error);
+                alert("Login failed due to a network/server issue.");
             }
         });
     }
@@ -83,7 +114,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const logoutBtn = document.getElementById("logoutBtn");
     if (logoutBtn) {
         logoutBtn.addEventListener("click", async () => {
-            await fetch("/logout", { credentials: "same-origin" });
+            await fetch("/logout", { credentials: "include" });
             alert("Logged out successfully!");
             // Send the user back to login after logout
             window.location.href = "/login.html";
@@ -100,22 +131,32 @@ document.addEventListener("DOMContentLoaded", () => {
         taskForm.addEventListener("submit", submit);
     }
 
-    checkAuthStatus(); // Check authentication status on page load
+    checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage }); // Check authentication status on page load
 });
 
 // Function to check if a user is currently logged in
-async function checkAuthStatus() {
-    const response = await fetch("/auth-status");
-    const data = await response.json();
-
+async function checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage }) {
     const authSection = document.getElementById("auth-section");
     const mainSection = document.getElementById("main-section");
     const authStatus = document.getElementById("authStatus");
     const logoutBtn = document.getElementById("logoutBtn");
 
+    let data = { loggedIn: false };
+
+    try {
+        const response = await fetch("/auth-status", {
+            credentials: "include",
+            cache: "no-store"
+        });
+
+        data = await parseApiResponse(response);
+    } catch (error) {
+        console.error("Auth status check failed:", error);
+    }
+
     if (data.loggedIn) {
         // Keep login/register pages from showing when already authenticated
-        if (document.body.classList.contains("login-page") || document.body.classList.contains("register-page")) {
+        if (isLoginPage || isRegisterPage) {
             window.location.href = "/dashboard.html";
             return;
         }
@@ -147,6 +188,12 @@ async function checkAuthStatus() {
             fetchTasks(); // Automatically load tasks if user is logged in
         }
     } else {
+        // Protected pages should send logged-out users to login instead of showing a blank shell.
+        if (isProtectedPage) {
+            window.location.href = "/login.html";
+            return;
+        }
+
         // Only toggle dashboard sections if they are present on the page
         if (authStatus) {
             authStatus.textContent = "Not logged in";
@@ -166,7 +213,7 @@ async function checkAuthStatus() {
 
 // Function to get the tasks for the logged in user
 async function fetchTasks() {
-    const response = await fetch("/tasks");
+    const response = await fetch("/tasks", { credentials: "include" });
     const tasks = await response.json();
 
     if (response.ok) {
@@ -200,6 +247,7 @@ const submit = async function(event) {
 
     // Send task data to the server
     const response = await fetch("/tasks", {
+        credentials: "include",
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(json)

--- a/server.js
+++ b/server.js
@@ -40,6 +40,7 @@ app.use(session({
   secret: process.env.SESSION_SECRET || "fallback_secret",
   resave: false,
   saveUninitialized: false,
+  rolling: true,
   store: MongoStore.create({
     mongoUrl: process.env.MONGO_URI,
     collectionName: "sessions",
@@ -48,7 +49,8 @@ app.use(session({
   cookie: {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production", // https only in prod
-    sameSite: "lax"
+    sameSite: "lax",
+    maxAge: REMEMBER_ME_MS
   }
 }));
 
@@ -89,6 +91,7 @@ app.post("/login", (req, res, next) => {
   const { rememberMe } = req.body;
 
   passport.authenticate("local", (err, user, info) => {
+    if (err) return next(err);
     if (!user) return res.status(401).json({ error: info?.message || "Login failed" });
 
     req.logIn(user, (loginErr) => {
@@ -97,7 +100,8 @@ app.post("/login", (req, res, next) => {
       if (rememberMe) {
         req.session.cookie.maxAge = REMEMBER_ME_MS;
       } else {
-        req.session.cookie.expires = false;
+        // Keep a bounded persistent cookie to improve Safari/PWA reliability.
+        req.session.cookie.maxAge = 24 * 60 * 60 * 1000;
       }
 
       return res.json({
@@ -115,7 +119,10 @@ app.get("/logout", (req, res) => {
         if (err) {
             return res.status(500).json({ error: "Error logging out" });
         }
-        res.json({ message: "Logged out successfully" });
+        req.session.destroy(() => {
+          res.clearCookie("connect.sid");
+          res.json({ message: "Logged out successfully" });
+        });
     });
 });
 


### PR DESCRIPTION
### Motivation
- A recent merge/revert introduced a regression where client-side JSON parsing failures from non-JSON/error payloads could break login/register flows and prevent redirects to the dashboard. 
- Session handling and logout behavior could leave stale cookies/sessions and the passport callback did not explicitly handle authentication errors, causing intermittent failures.

### Description
- Added a shared `parseApiResponse` helper in `public/js/main.js` to safely handle non-JSON or HTML error responses instead of throwing during `response.json()` parsing. 
- Wrapped the login and register client requests in `try/catch` and switched them to use `parseApiResponse`, with clearer user-facing failure messages for network/server issues and `credentials: 'include'` for session requests. 
- Updated bootstrapping `checkAuthStatus` to use the safe parser and accept page flags (`isLoginPage`, `isRegisterPage`, `isProtectedPage`) so protected pages redirect unauthenticated users reliably. 
- On the server, hardened the login flow by checking `if (err) return next(err)` inside `passport.authenticate` and made session behavior explicit by setting `rolling: true`, a default `cookie.maxAge` in session middleware, and setting a bounded cookie when `rememberMe` is false. 
- Improved logout reliability by destroying the session server-side and clearing the `connect.sid` cookie on logout.

### Testing
- Ran `node --check public/js/main.js` which completed successfully. 
- Ran `node --check server.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b3aaefa748326b18a76223ff0ea4c)