### PR TITLE
Harden DB initialization to prevent registration crashes

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -1,14 +1,26 @@
 const mongoose = require("mongoose");
 require("dotenv").config(); // Load environment variables
 
+let cachedConnection = null;
+
 // Connect to the database
 const connectDB = async () => {
+    if (cachedConnection) {
+        return cachedConnection;
+    }
+
+    if (!process.env.MONGO_URI) {
+        throw new Error("MONGO_URI environment variable is required");
+    }
+
     try {
-        await mongoose.connect(process.env.MONGO_URI); // Just pass the connection string
+        cachedConnection = await mongoose.connect(process.env.MONGO_URI); // Just pass the connection string
         console.log("✅ MongoDB Connected Successfully!");
+        return cachedConnection;
     } catch (err) {
+        cachedConnection = null;
         console.error("❌ MongoDB Connection Failed:", err);
-        process.exit(1); // Exit the app if the connection fails
+        throw err;
     }
 };
 

--- a/server.js
+++ b/server.js
@@ -25,7 +25,17 @@ if (!process.env.SESSION_SECRET) {
 }
 
 // Connect to MongoDB
-connectDB();
+const dbReady = connectDB();
+
+app.use(async (req, res, next) => {
+  try {
+    await dbReady;
+    return next();
+  } catch (error) {
+    console.error("Database unavailable for request", error);
+    return res.status(503).json({ error: "Service temporarily unavailable" });
+  }
+});
 
 // Middleware -----------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Motivation

- Registration endpoints were intermittently failing because a hard DB failure could terminate the process (surfacing as serverless `FUNCTION_INVOCATION_FAILED`) and cause unpredictable behavior during user registration.
- The goal is to avoid exiting the runtime on transient Mongo connection failures and ensure request handlers wait for DB readiness instead of crashing.

### Description

- Updated `config/database.js` to cache the MongoDB connection in `cachedConnection`, validate `MONGO_URI`, and throw errors instead of calling `process.exit(1)` on connection failure.
- Changed DB connect semantics to return the connection promise from `connectDB()` so callers can await readiness without re-establishing connections.
- Modified `server.js` to create a shared `dbReady` promise by calling `connectDB()` once and added an express middleware that awaits `dbReady` and returns HTTP `503` JSON if the database is unavailable.
- These changes prevent process termination on initial DB errors and ensure registration/login/task routes only run after the DB initialization attempt completes.

### Testing

- Ran `node --check server.js` which succeeded with no syntax errors.
- Ran `node --check config/database.js` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ea5c02f908326a61d97fa8ebd22a5)