### PR TITLE
Handle DB startup failures and robustify client JSON parsing

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -1,14 +1,26 @@
 const mongoose = require("mongoose");
 require("dotenv").config(); // Load environment variables
 
+let cachedConnection = null;
+
 // Connect to the database
 const connectDB = async () => {
+    if (cachedConnection) {
+        return cachedConnection;
+    }
+
+    if (!process.env.MONGO_URI) {
+        throw new Error("MONGO_URI environment variable is required");
+    }
+
     try {
-        await mongoose.connect(process.env.MONGO_URI); // Just pass the connection string
+        cachedConnection = await mongoose.connect(process.env.MONGO_URI); // Just pass the connection string
         console.log("✅ MongoDB Connected Successfully!");
+        return cachedConnection;
     } catch (err) {
+        cachedConnection = null;
         console.error("❌ MongoDB Connection Failed:", err);
-        process.exit(1); // Exit the app if the connection fails
+        throw err;
     }
 };
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,8 +2,14 @@
 
 async function parseApiResponse(response) {
     const contentType = response.headers.get("content-type") || "";
+
     if (contentType.includes("application/json")) {
-        return response.json();
+        try {
+            return await response.json();
+        } catch (error) {
+            const fallbackText = await response.text().catch(() => "");
+            return { error: fallbackText || "Unexpected server response" };
+        }
     }
 
     const text = await response.text();

--- a/server.js
+++ b/server.js
@@ -25,7 +25,22 @@ if (!process.env.SESSION_SECRET) {
 }
 
 // Connect to MongoDB
-connectDB();
+let dbInitError = null;
+const dbReady = connectDB().catch((error) => {
+  dbInitError = error;
+  return null;
+});
+
+app.use(async (req, res, next) => {
+  await dbReady;
+
+  if (dbInitError) {
+    console.error("Database unavailable for request", dbInitError);
+    return res.status(503).json({ error: "Service temporarily unavailable" });
+  }
+
+  return next();
+});
 
 // Middleware -----------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Motivation
- Prevent the process from crashing or returning unclear 500s during early MongoDB connection failures so request handlers can return a controlled `503` instead of causing downstream errors.  
- Avoid frontend runtime exceptions when the server (or platform) returns a non-JSON error body while the client still attempts `response.json()`.

### Description
- Updated `config/database.js` to cache the Mongo connection in `cachedConnection`, validate `MONGO_URI`, return the connection promise, and throw errors instead of calling `process.exit(1)` on failure.  
- Changed `server.js` to capture startup connection errors in `dbInitError`, expose a `dbReady` promise from `connectDB()`, and add middleware that `await`s `dbReady` and returns HTTP `503` JSON when the DB is unavailable.  
- Hardened client parsing in `public/js/main.js` by wrapping `response.json()` in a `try/catch` and falling back to `response.text()` so non-JSON error payloads are surfaced as an `{ error: ... }` object instead of causing a parse exception.

### Testing
- Ran `node --check server.js` which succeeded.  
- Ran `node --check config/database.js` which succeeded.  
- Ran `node --check public/js/main.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ea5c02f908326a61d97fa8ebd22a5)