### PR TITLE
Refine right-column widget sizing so all content remains visible

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -446,7 +446,7 @@ input:focus{
 /* =========================================================
    DASHBOARD LAYOUT
    - corkboard = board container
-   - board-grid = 3 columns desktop, collapses on smaller screens
+   - board-grid = 2 columns desktop, collapses on smaller screens
    ========================================================= */
 
 /* Corkboard container (Desktop default: NOT scrollable) */
@@ -483,7 +483,7 @@ input:focus{
 /* Main grid */
 .board-grid{
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 1fr 1fr;
   column-gap: 5%;
   row-gap: var(--board-gap);
   height: 100%;
@@ -511,7 +511,7 @@ input:focus{
 /* Right column: Focus mode sits above reflections */
 .board-grid #focus-mode-widget{
   height: auto;
-  flex: 0 0 35%;
+  flex: 0 0 auto;
   margin-bottom: 8px;
 }
 
@@ -529,6 +529,11 @@ input:focus{
   flex: 1;
   min-height: 0;
   height: auto;
+}
+
+/* Left column keeps task list full-height */
+.board-grid > div:first-child #task-list-widget{
+  flex: 1;
 }
 
 
@@ -555,6 +560,21 @@ input:focus{
 #create-task-widget .paper-form select{
   width: 100%;
   background: transparent;
+}
+
+#create-task-widget .task-meta-row{
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  align-items: start;
+}
+
+#create-task-widget .task-meta-row .paper-field{
+  margin-bottom: 0;
+}
+
+#create-task-widget .effort-field .effort-options{
+  margin-top: 4px;
 }
 
 /* Effort selector (radio chips) */
@@ -870,12 +890,93 @@ input:focus{
    - keep your “board proportions” without breaking mobile
    ========================================================= */
 @media (min-width: 1024px){
-  #big-3-tasks{ height: 50% !important; }
-  #focus-mode-widget{ height: 50% !important; }
-  #reflection-section{ height: 80% !important; }
-  #daily-reflection{ height: 50% !important; }
-  #weekly-reflection{ height: 50% !important; }
-  #create-task-widget{ height: 50% !important; }
+  #task-list-widget{ height: 100% !important; }
+
+  /* Force right column widgets to fit entirely within corkboard height */
+  .board-grid > div:nth-child(2){
+    display: grid;
+    grid-template-rows: minmax(0, 1.35fr) minmax(0, 0.85fr) minmax(0, 0.85fr) minmax(0, 1fr);
+    gap: 12px;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .board-grid > div:nth-child(2) #create-task-widget,
+  .board-grid > div:nth-child(2) #big-3-tasks,
+  .board-grid > div:nth-child(2) #focus-mode-widget,
+  .board-grid > div:nth-child(2) #reflection-section{
+    height: 100% !important;
+    min-height: 0;
+    margin: 0;
+  }
+
+  /* Right-column content sizing so all widget content stays visible cleanly */
+  .board-grid > div:nth-child(2) .sticky-note{
+    padding: 0.72rem;
+  }
+
+  .board-grid > div:nth-child(2) .widget-title{
+    margin-bottom: 0.4rem;
+    font-size: clamp(1rem, 1.2vw, 1.25rem);
+    line-height: 1.2;
+  }
+
+  #create-task-widget,
+  #big-3-tasks,
+  #focus-mode-widget,
+  #daily-reflection,
+  #weekly-reflection{
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  #create-task-widget .paper-form{
+    padding: 10px 12px 12px;
+    gap: 8px;
+  }
+
+  #create-task-widget .paper-field label{
+    font-size: 0.95rem;
+    margin-bottom: 4px;
+  }
+
+  #create-task-widget .paper-form input{
+    padding: 8px 10px;
+    font-size: 0.95rem;
+  }
+
+  #create-task-widget .task-meta-row{
+    gap: 8px;
+  }
+
+  #create-task-widget .effort-options{
+    gap: 6px;
+  }
+
+  #create-task-widget .effort-option{
+    padding: 6px 9px;
+    font-size: 0.9rem;
+  }
+
+  #create-task-widget #submitBtn{
+    margin-top: 4px;
+    padding: 10px 0;
+  }
+
+  #focus-mode-widget p{
+    margin: 0 0 6px;
+    font-size: 0.95rem;
+  }
+
+  #focus-button{
+    width: min(170px, 70%);
+    margin-top: 6px;
+  }
+
+  #reflection-section{ height: 100% !important; }
+  #daily-reflection,
+  #weekly-reflection{ height: 100% !important; }
 }
 
 
@@ -952,6 +1053,10 @@ input:focus{
 
   #task-list-widget{ min-height: 380px; }
   #create-task-widget{ min-height: 320px; }
+
+  #create-task-widget .task-meta-row{
+    grid-template-columns: 1fr;
+  }
 
   /* Keep focus mode content inside note */
   #focus-mode-widget{

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -108,7 +108,7 @@
             </div>
           </div>
 
-          <!-- Middle Column -->
+          <!-- Right Column -->
           <div>
             <!-- Create New Task -->
             <div id="create-task-widget" class="sticky-note blue thumbtack">
@@ -127,39 +127,41 @@
                     required
                   />
                 </div>
-                <div class="paper-field">
-                  <label for="dueDate">Due Date</label>
-                  <input id="dueDate" type="date" name="dueDate" />
-                </div>
-                
-                <div class="paper-field">
-                  <label>Effort Level (1 being easy and 5 being heavy)</label>
+                <div class="task-meta-row">
+                  <div class="paper-field">
+                    <label for="dueDate">Due Date</label>
+                    <input id="dueDate" type="date" name="dueDate" />
+                  </div>
 
-                  <div class="effort-options" role="radiogroup" aria-label="Effort level">
-                    <label class="effort-option">
-                      <input type="radio" name="effortLevel" value="1" required>
-                      1
-                    </label>
+                  <div class="paper-field effort-field">
+                    <label>Effort Level (1–5)</label>
 
-                    <label class="effort-option">
-                      <input type="radio" name="effortLevel" value="2">
-                      2
-                    </label>
+                    <div class="effort-options" role="radiogroup" aria-label="Effort level">
+                      <label class="effort-option">
+                        <input type="radio" name="effortLevel" value="1" required>
+                        1
+                      </label>
 
-                    <label class="effort-option">
-                      <input type="radio" name="effortLevel" value="3" checked>
-                      3
-                    </label>
+                      <label class="effort-option">
+                        <input type="radio" name="effortLevel" value="2">
+                        2
+                      </label>
 
-                    <label class="effort-option">
-                      <input type="radio" name="effortLevel" value="4">
-                      4
-                    </label>
+                      <label class="effort-option">
+                        <input type="radio" name="effortLevel" value="3" checked>
+                        3
+                      </label>
 
-                    <label class="effort-option">
-                      <input type="radio" name="effortLevel" value="5">
-                      5
-                    </label>
+                      <label class="effort-option">
+                        <input type="radio" name="effortLevel" value="4">
+                        4
+                      </label>
+
+                      <label class="effort-option">
+                        <input type="radio" name="effortLevel" value="5">
+                        5
+                      </label>
+                    </div>
                   </div>
                 </div>
 
@@ -177,10 +179,7 @@
                 Big 3 Tasks
               </h2>
             </div>
-          </div>
 
-          <!-- Right Column -->
-          <div>
             <!-- Focus Mode Widget -->
             <div id="focus-mode-widget" class="sticky-note blue thumbtack">
               <h3 class="widget-title highlight-on-parent-hover">Focus Mode</h3>


### PR DESCRIPTION
### Motivation
- Prevent right-column widgets from overflowing the corkboard by making their internal elements more compact and enabling safe overflow handling on desktop. 
- Ensure each right-column sticky note shows its full content cleanly (titles, form controls, effort chips, focus controls) while keeping existing responsive behavior for tablet/phone. 

### Description
- Layout: switched the main board to a two-column desktop grid and ensured the left column (`#task-list-widget`) stays full-height while the right column becomes a 4-row CSS grid under `@media (min-width: 1024px)` to enforce widget proportions. 
- Sizing tweaks: reduced right-column sticky padding and scaled down title typography with a `clamp()`-based font size to free vertical space inside each widget. 
- Create Task refinements: added a `.task-meta-row` in `dashboard.html` and CSS to place `Due Date` and `Effort` side-by-side, compacted `.paper-form` padding/gap, lowered label/input font sizes and input padding, and reduced `.effort-option` chip padding/font-size to avoid clipping. 
- Overflow and Focus tweaks: enabled `overflow-y: auto` for right-column widgets, adjusted `#focus-mode-widget` text and `#focus-button` sizing so the content fits, and kept reflections full-height inside the constrained grid. 

### Testing
- Served the `public/` folder with `python3 -m http.server 4173` and the server started successfully (succeeded). 
- Ran a Playwright script to load `http://127.0.0.1:4173/dashboard.html` and capture a screenshot to visually verify the right-column widgets now display their full content cleanly (succeeded). 
- Verified the updated files are `public/css/main.css` and `public/dashboard.html` and that the UI layout behaves correctly across desktop and smaller breakpoints (visual checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f602ca6e08326929915a7ed53e462)