### PR TITLE
Remove Create Task title and top-align submit button; improve create-form layout and desktop sizing

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -446,7 +446,7 @@ input:focus{
 /* =========================================================
    DASHBOARD LAYOUT
    - corkboard = board container
-   - board-grid = 3 columns desktop, collapses on smaller screens
+   - board-grid = 2 columns desktop, collapses on smaller screens
    ========================================================= */
 
 /* Corkboard container (Desktop default: NOT scrollable) */
@@ -483,7 +483,7 @@ input:focus{
 /* Main grid */
 .board-grid{
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 1fr 1fr;
   column-gap: 5%;
   row-gap: var(--board-gap);
   height: 100%;
@@ -511,7 +511,7 @@ input:focus{
 /* Right column: Focus mode sits above reflections */
 .board-grid #focus-mode-widget{
   height: auto;
-  flex: 0 0 35%;
+  flex: 0 0 auto;
   margin-bottom: 8px;
 }
 
@@ -531,6 +531,11 @@ input:focus{
   height: auto;
 }
 
+/* Left column keeps task list full-height */
+.board-grid > div:first-child #task-list-widget{
+  flex: 1;
+}
+
 
 /* =========================================================
    DASHBOARD WIDGETS
@@ -542,12 +547,11 @@ input:focus{
   flex-direction: column;
 }
 
-/* Keep the form usable inside the sticky note */
+/* Keep the form usable inside the sticky note (no scrolling) */
 #create-task-widget .paper-form{
   flex: 1;
-  max-height: calc(100% - 40px);
-  overflow-y: auto;
-  overflow-x: hidden;
+  max-height: none;
+  overflow: hidden;
 }
 
 /* Ensure inputs/selects fill the widget */
@@ -555,6 +559,32 @@ input:focus{
 #create-task-widget .paper-form select{
   width: 100%;
   background: transparent;
+}
+
+/* Create Task layout: task top-left, due below-left, effort top-right, submit bottom-right */
+#create-task-widget .create-task-form-grid{
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas:
+    "task effort"
+    "due effort"
+    ". submit";
+  gap: 8px 10px;
+  align-content: stretch;
+}
+
+#create-task-widget .task-field{ grid-area: task; }
+#create-task-widget .due-field{ grid-area: due; }
+#create-task-widget .effort-field{ grid-area: effort; margin-bottom: 0; }
+#create-task-widget #submitBtn{ grid-area: submit; justify-self: end; align-self: start; margin-top: 0; width: 140px; }
+
+#create-task-widget .task-field,
+#create-task-widget .due-field{
+  margin-bottom: 0;
+}
+
+#create-task-widget .effort-field .effort-options{
+  margin-top: 4px;
 }
 
 /* Effort selector (radio chips) */
@@ -870,12 +900,93 @@ input:focus{
    - keep your “board proportions” without breaking mobile
    ========================================================= */
 @media (min-width: 1024px){
-  #big-3-tasks{ height: 50% !important; }
-  #focus-mode-widget{ height: 50% !important; }
-  #reflection-section{ height: 80% !important; }
-  #daily-reflection{ height: 50% !important; }
-  #weekly-reflection{ height: 50% !important; }
-  #create-task-widget{ height: 50% !important; }
+  #task-list-widget{ height: 100% !important; }
+
+  /* Force right column widgets to fit entirely within corkboard height */
+  .board-grid > div:nth-child(2){
+    display: grid;
+    grid-template-rows: minmax(0, 1.55fr) minmax(0, 0.78fr) minmax(0, 0.78fr) minmax(0, 0.9fr);
+    gap: 16px;
+    height: 100%;
+    min-height: 0;
+    padding-top: 14px;
+    overflow: visible;
+  }
+
+  .board-grid > div:nth-child(2) #create-task-widget,
+  .board-grid > div:nth-child(2) #big-3-tasks,
+  .board-grid > div:nth-child(2) #focus-mode-widget,
+  .board-grid > div:nth-child(2) #reflection-section{
+    height: 100% !important;
+    min-height: 0;
+    margin: 0;
+  }
+
+  /* Right-column content sizing so all widget content stays visible cleanly */
+  .board-grid > div:nth-child(2) .sticky-note{
+    padding: 0.72rem;
+  }
+
+  .board-grid > div:nth-child(2) .widget-title{
+    margin-bottom: 0.4rem;
+    font-size: clamp(1rem, 1.2vw, 1.25rem);
+    line-height: 1.2;
+  }
+
+  #big-3-tasks,
+  #focus-mode-widget,
+  #daily-reflection,
+  #weekly-reflection{
+    overflow-y: visible;
+    overflow-x: visible;
+  }
+
+  #create-task-widget{
+    overflow: visible;
+  }
+
+  #create-task-widget .paper-form{
+    padding: 10px 12px 12px;
+    gap: 8px;
+  }
+
+  #create-task-widget .paper-field label{
+    font-size: 0.95rem;
+    margin-bottom: 4px;
+  }
+
+  #create-task-widget .paper-form input{
+    padding: 8px 10px;
+    font-size: 0.95rem;
+  }
+
+    #create-task-widget .effort-options{
+    gap: 6px;
+  }
+
+  #create-task-widget .effort-option{
+    padding: 6px 9px;
+    font-size: 0.9rem;
+  }
+
+  #create-task-widget #submitBtn{
+    margin-top: 4px;
+    padding: 10px 0;
+  }
+
+  #focus-mode-widget p{
+    margin: 0 0 6px;
+    font-size: 0.95rem;
+  }
+
+  #focus-button{
+    width: min(170px, 70%);
+    margin-top: 6px;
+  }
+
+  #reflection-section{ height: 100% !important; }
+  #daily-reflection,
+  #weekly-reflection{ height: 100% !important; }
 }
 
 
@@ -952,6 +1063,20 @@ input:focus{
 
   #task-list-widget{ min-height: 380px; }
   #create-task-widget{ min-height: 320px; }
+
+  #create-task-widget .create-task-form-grid{
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "task"
+      "due"
+      "effort"
+      "submit";
+  }
+
+  #create-task-widget #submitBtn{
+    justify-self: stretch;
+    width: 100%;
+  }
 
   /* Keep focus mode content inside note */
   #focus-mode-widget{

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -108,16 +108,12 @@
             </div>
           </div>
 
-          <!-- Middle Column -->
+          <!-- Right Column -->
           <div>
             <!-- Create New Task -->
             <div id="create-task-widget" class="sticky-note blue thumbtack">
-              <h2 class="widget-title highlight-on-parent-hover">
-                <i class="fa-solid fa-pen" style="color: #c6534e"></i>
-                New Task
-              </h2>
-              <form id="taskForm" class="paper-form">
-                <div class="paper-field">
+              <form id="taskForm" class="paper-form create-task-form-grid">
+                <div class="paper-field task-field">
                   <label for="taskDescription">Task</label>
                   <input
                     id="taskDescription"
@@ -127,13 +123,14 @@
                     required
                   />
                 </div>
-                <div class="paper-field">
+
+                <div class="paper-field due-field">
                   <label for="dueDate">Due Date</label>
                   <input id="dueDate" type="date" name="dueDate" />
                 </div>
-                
-                <div class="paper-field">
-                  <label>Effort Level (1 being easy and 5 being heavy)</label>
+
+                <div class="paper-field effort-field">
+                  <label>Effort Level (1–5)</label>
 
                   <div class="effort-options" role="radiogroup" aria-label="Effort level">
                     <label class="effort-option">
@@ -164,7 +161,7 @@
                 </div>
 
                 <button id="submitBtn" class="paper-button" type="submit" >
-                  Pin it! 
+                  Pin it!
                 </button>
               </form>
             </div>
@@ -177,10 +174,7 @@
                 Big 3 Tasks
               </h2>
             </div>
-          </div>
 
-          <!-- Right Column -->
-          <div>
             <!-- Focus Mode Widget -->
             <div id="focus-mode-widget" class="sticky-note blue thumbtack">
               <h3 class="widget-title highlight-on-parent-hover">Focus Mode</h3>


### PR DESCRIPTION
### Motivation
- Remove the redundant "New Task" widget title so the create-task form starts at the top of its sticky note and saves vertical space.
- Bring the submit button to the top of its grid area so the CTA is immediately visible and easier to access.
- Improve the create-task form layout and related dashboard sizing to ensure widgets fit cleanly inside the corkboard on desktop and remain responsive on smaller screens.

### Description
- Removed the `<h2 class="widget-title">` header from the Create Task widget in `public/dashboard.html` and switched the form to use the `create-task-form-grid` class.
- Added a grid layout for the create-task form in `public/css/main.css` with named grid areas (`task`, `due`, `effort`, `submit`) and moved the submit button into the `submit` area.
- Updated submit button alignment to `align-self: start` and kept it right-aligned with `justify-self: end` so it sits at the top-right of its cell while preserving width.
- Adjusted form container behavior and overall dashboard layout: changed `.board-grid` to two columns, removed form scrolling by setting `.paper-form` max-height to `none`/`overflow: hidden`, and added desktop sizing rules to keep right-column widgets visible and well-proportioned; also added responsive fallback for the create-task grid on narrow screens to stack fields and expand the submit button.

### Testing
- Served the `public/` directory with `python3 -m http.server 4173` and confirmed the site responded successfully.
- Captured a Playwright screenshot of `http://127.0.0.1:4173/dashboard.html` using a short script to verify the title was removed and the submit button is top-aligned, and the screenshot was produced successfully.
- Committed the changes to the repo, and the commit operation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f602ca6e08326929915a7ed53e462)