### PR TITLE
Update delete button icon to eraser

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -107,7 +107,7 @@
                       <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
                     </button>
                     <button type="button" class="task-action-btn delete-btn" aria-label="Delete task" title="Delete">
-                      <i class="fa-solid fa-trash" aria-hidden="true"></i>
+                      <i class="fa-solid fa-eraser" aria-hidden="true"></i>
                     </button>
                   </div>
                   <label class="checkbox-container">


### PR DESCRIPTION
### Motivation
- Swap the delete action icon in the task template to an eraser symbol for clearer UX by replacing the Font Awesome `fa-trash` class with `fa-eraser` in the dashboard template.

### Description
- Changed the icon class in `public/dashboard.html` from `fa-solid fa-trash` to `fa-solid fa-eraser` while leaving button behavior and accessibility attributes unchanged.

### Testing
- Verified the change with a code search using `rg` to confirm `fa-eraser` is present and `fa-trash` removed from `public/dashboard.html`.
- Ran `npm start` to attempt a visual verification but the server failed to start in this environment due to MongoDB DNS resolution (`querySrv ENOTFOUND _mongodb._tcp.cluster0.fyexz.mongodb.net`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994503772e08326846b92758b6ea676)