### PR TITLE
Apply task-text styling to 'Remember me' label on login page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -857,6 +857,11 @@ input:focus{
   opacity: 0.6;
 }
 
+.login-page .paper-actions .checkbox-container .task-text{
+  font-family: "Itim", serif;
+  font-style: normal;
+}
+
 /* Scrolling list area (inside a widget) */
 .task-list.scrollable{
   flex: 1;

--- a/public/login.html
+++ b/public/login.html
@@ -53,7 +53,7 @@
             <label class="checkbox-container">
               <input id="rememberMe" type="checkbox" class="task-check" />
               <span class="checkmark"></span>
-              <span>Remember me</span>
+              <span class="task-text">Remember me</span>
             </label>
             <a href="#">Forgot password?</a>
           </div>


### PR DESCRIPTION
### Motivation
- Ensure the login form "Remember me" label uses the shared `task-text` typography so it appears consistent on both mobile and desktop layouts.

### Description
- Add the `task-text` class to the "Remember me" span in `public/login.html` so it inherits existing task styling.

### Testing
- Verified the change was applied with a repository search (`rg`) which found `<span class="task-text">Remember me</span>` in `public/login.html` (succeeded).  
- Attempted to run the app for visual verification but the server exited due to a MongoDB SRV DNS resolution error (`ENOTFOUND _mongodb._tcp.cluster0.fyexz.mongodb.net`) (failed).  
- Attempted an automated Playwright screenshot of the page but the browser run could not load the file in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699489f843c883269ffc727f0f339bff)