### PR TITLE
Add shared desktop/mobile navbar to remaining pages

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -1,47 +1,43 @@
-<nav id="main-menu">
-  <!-- Logo/Site Name -->
-  <div id="site-logo">
-    <a href="/dashboard.html">
-      <h2>Board</h2>
-    </a>
-  </div>
-  <!-- Nav Links -->
-  <!-- Could be populated by a mongo db table with names and links -->
-  <div id="nav-links">
-    <div>
-      <a href="calendar-page.html"> <h3>Calendar</h3></a>
-    </div>
-    <h3>|</h3>
-    <div>
-      <a href="feedback-page.html"> <h3>Feedback</h3></a>
-    </div>
-    <h3>|</h3>
-    <div>
-      <a href="settings-page.html"> <h3>Settings</h3></a>
-    </div>
-  </div>
+<nav class="navbar">
+  <div class="nav-left">
+    <button
+      class="nav__toggle"
+      type="button"
+      aria-label="Open menu"
+      aria-controls="nav-drawer"
+      aria-expanded="false"
+    >
+      <i class="fa-solid fa-bars" aria-hidden="true"></i>
+      <span class="sr-only">Menu</span>
+    </button>
 
-  <!-- Profile Section -->
-  <div id="profile-section">
-    <!-- Tasks Left -->
-    <div id="task-counter">
-      <h3 style="font-weight: 100">
-        Tasks Left: <span class="item-counter sticky-note thumbtack"></span>
-      </h3>
-    </div>
-
-    <!-- Profile Button -->
-    <div id="profile-button" class="profile-dropdown">
-      <button
-        class="profile-trigger sticky-note double-tape"
-        aria-haspopup="true"
-      >
-        <span id="authStatus"></span>
-        <span class="chevron">▾</span>
-      </button>
-      <div class="profile-menu">
-        <button id="logoutBtn">Log Out</button>
+    <div class="logo-container">
+      <div class="logo-sticky">
+        <div class="thumbtack">
+          <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+        </div>
       </div>
+      <span class="brand-name">Stick A Pin</span>
+    </div>
+  </div>
+
+  <ul class="nav-links" id="nav-drawer">
+    <li><a href="/dashboard.html" class="nav-item">Board</a></li>
+    <li><a href="/calendar-page.html" class="nav-item active">Calendar</a></li>
+    <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
+    <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
+    <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
+    <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
+  </ul>
+
+  <div class="nav-right">
+    <div class="nav-status">
+      <div class="nav-tasks">
+        <span class="tasks-count item-counter"></span>
+        <span class="tasks-label-text">Tasks Left</span>
+      </div>
+      <span id="authStatus" class="nav-welcome"></span>
     </div>
   </div>
 </nav>
+<div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -1,43 +1,92 @@
-<nav class="navbar">
-  <div class="nav-left">
-    <button
-      class="nav__toggle"
-      type="button"
-      aria-label="Open menu"
-      aria-controls="nav-drawer"
-      aria-expanded="false"
-    >
-      <i class="fa-solid fa-bars" aria-hidden="true"></i>
-      <span class="sr-only">Menu</span>
-    </button>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Stick A Pin</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="js/notification.js" defer></script>
+    <script src="js/main.js" defer></script>
+    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
+    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/stickies.css" />
+    <link rel="stylesheet" href="css/notification.css" />
+    <link rel="stylesheet" href="css/navbar.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
+    />
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="nav-left">
+        <button
+          class="nav__toggle"
+          type="button"
+          aria-label="Open menu"
+          aria-controls="nav-drawer"
+          aria-expanded="false"
+        >
+          <i class="fa-solid fa-bars" aria-hidden="true"></i>
+          <span class="sr-only">Menu</span>
+        </button>
 
-    <div class="logo-container">
-      <div class="logo-sticky">
-        <div class="thumbtack">
-          <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+        <div class="logo-container">
+          <div class="logo-sticky">
+            <div class="thumbtack">
+              <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+            </div>
+          </div>
+          <span class="brand-name">Stick A Pin</span>
         </div>
       </div>
-      <span class="brand-name">Stick A Pin</span>
-    </div>
-  </div>
 
-  <ul class="nav-links" id="nav-drawer">
-    <li><a href="/dashboard.html" class="nav-item">Board</a></li>
-    <li><a href="/calendar-page.html" class="nav-item active">Calendar</a></li>
-    <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
-    <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-    <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
-    <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
-  </ul>
+      <ul class="nav-links" id="nav-drawer">
+        <li><a href="/dashboard.html" class="nav-item">Board</a></li>
+        <li><a href="/calendar-page.html" class="nav-item active">Calendar</a></li>
+        <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
+        <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
+        <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
+        <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
+      </ul>
 
-  <div class="nav-right">
-    <div class="nav-status">
-      <div class="nav-tasks">
-        <span class="tasks-count item-counter"></span>
-        <span class="tasks-label-text">Tasks Left</span>
+      <div class="nav-right">
+        <div class="nav-status">
+          <div class="nav-tasks">
+            <span class="tasks-count item-counter"></span>
+            <span class="tasks-label-text">Tasks Left</span>
+          </div>
+          <span id="authStatus" class="nav-welcome"></span>
+        </div>
       </div>
-      <span id="authStatus" class="nav-welcome"></span>
+    </nav>
+    <div id="nav-backdrop" aria-hidden="true"></div>
+
+    <main class="corkboard" style="max-width: 1100px; margin: 2rem auto;">
+      <section class="sticky-note blue thumbtack" style="padding: 1.25rem;">
+        <h1 class="widget-title">
+          <i class="fa-solid fa-calendar-days" style="color: #c6534e;"></i>
+          Calendar
+        </h1>
+        <p>Calendar view is coming soon. Use the board to manage your tasks today.</p>
+      </section>
+    </main>
+
+    <div id="toast" class="toast toast--default" role="status" aria-live="polite" aria-atomic="true" hidden>
+      <div class="toast__icon" aria-hidden="true">i</div>
+      <div class="toast__content">
+        <div id="toastTitle" class="toast__title" hidden></div>
+        <div id="toastMessage" class="toast__message"></div>
+      </div>
+      <button id="toastClose" class="toast__close" type="button" aria-label="Close notification">×</button>
+      <div class="toast__progress"></div>
     </div>
-  </div>
-</nav>
-<div id="nav-backdrop" aria-hidden="true"></div>
+  </body>
+</html>

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -1,47 +1,43 @@
-<nav id="main-menu">
-  <!-- Logo/Site Name -->
-  <div id="site-logo">
-    <a href="/dashboard.html">
-      <h2>Board</h2>
-    </a>
-  </div>
-  <!-- Nav Links -->
-  <!-- Could be populated by a mongo db table with names and links -->
-  <div id="nav-links">
-    <div>
-      <a href="calendar-page.html"> <h3>Calendar</h3></a>
-    </div>
-    <h3>|</h3>
-    <div>
-      <a href="feedback-page.html"> <h3>Feedback</h3></a>
-    </div>
-    <h3>|</h3>
-    <div>
-      <a href="settings-page.html"> <h3>Settings</h3></a>
-    </div>
-  </div>
+<nav class="navbar">
+  <div class="nav-left">
+    <button
+      class="nav__toggle"
+      type="button"
+      aria-label="Open menu"
+      aria-controls="nav-drawer"
+      aria-expanded="false"
+    >
+      <i class="fa-solid fa-bars" aria-hidden="true"></i>
+      <span class="sr-only">Menu</span>
+    </button>
 
-  <!-- Profile Section -->
-  <div id="profile-section">
-    <!-- Tasks Left -->
-    <div id="task-counter">
-      <h3 style="font-weight: 100">
-        Tasks Left: <span class="item-counter sticky-note thumbtack"></span>
-      </h3>
-    </div>
-
-    <!-- Profile Button -->
-    <div id="profile-button" class="profile-dropdown">
-      <button
-        class="profile-trigger sticky-note double-tape"
-        aria-haspopup="true"
-      >
-        <span id="authStatus"></span>
-        <span class="chevron">▾</span>
-      </button>
-      <div class="profile-menu">
-        <button id="logoutBtn">Log Out</button>
+    <div class="logo-container">
+      <div class="logo-sticky">
+        <div class="thumbtack">
+          <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+        </div>
       </div>
+      <span class="brand-name">Stick A Pin</span>
+    </div>
+  </div>
+
+  <ul class="nav-links" id="nav-drawer">
+    <li><a href="/dashboard.html" class="nav-item">Board</a></li>
+    <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
+    <li><a href="/feedback-page.html" class="nav-item active">Feedback</a></li>
+    <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
+    <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
+    <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
+  </ul>
+
+  <div class="nav-right">
+    <div class="nav-status">
+      <div class="nav-tasks">
+        <span class="tasks-count item-counter"></span>
+        <span class="tasks-label-text">Tasks Left</span>
+      </div>
+      <span id="authStatus" class="nav-welcome"></span>
     </div>
   </div>
 </nav>
+<div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -1,43 +1,83 @@
-<nav class="navbar">
-  <div class="nav-left">
-    <button
-      class="nav__toggle"
-      type="button"
-      aria-label="Open menu"
-      aria-controls="nav-drawer"
-      aria-expanded="false"
-    >
-      <i class="fa-solid fa-bars" aria-hidden="true"></i>
-      <span class="sr-only">Menu</span>
-    </button>
-
-    <div class="logo-container">
-      <div class="logo-sticky">
-        <div class="thumbtack">
-          <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Stick A Pin</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="js/notification.js" defer></script>
+    <script src="js/main.js" defer></script>
+    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
+    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/stickies.css" />
+    <link rel="stylesheet" href="css/notification.css" />
+    <link rel="stylesheet" href="css/navbar.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
+    />
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="nav-left">
+        <button class="nav__toggle" type="button" aria-label="Open menu" aria-controls="nav-drawer" aria-expanded="false">
+          <i class="fa-solid fa-bars" aria-hidden="true"></i>
+          <span class="sr-only">Menu</span>
+        </button>
+        <div class="logo-container">
+          <div class="logo-sticky">
+            <div class="thumbtack">
+              <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+            </div>
+          </div>
+          <span class="brand-name">Stick A Pin</span>
         </div>
       </div>
-      <span class="brand-name">Stick A Pin</span>
-    </div>
-  </div>
-
-  <ul class="nav-links" id="nav-drawer">
-    <li><a href="/dashboard.html" class="nav-item">Board</a></li>
-    <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
-    <li><a href="/feedback-page.html" class="nav-item active">Feedback</a></li>
-    <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-    <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
-    <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
-  </ul>
-
-  <div class="nav-right">
-    <div class="nav-status">
-      <div class="nav-tasks">
-        <span class="tasks-count item-counter"></span>
-        <span class="tasks-label-text">Tasks Left</span>
+      <ul class="nav-links" id="nav-drawer">
+        <li><a href="/dashboard.html" class="nav-item">Board</a></li>
+        <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
+        <li><a href="/feedback-page.html" class="nav-item active">Feedback</a></li>
+        <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
+        <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
+        <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
+      </ul>
+      <div class="nav-right">
+        <div class="nav-status">
+          <div class="nav-tasks">
+            <span class="tasks-count item-counter"></span>
+            <span class="tasks-label-text">Tasks Left</span>
+          </div>
+          <span id="authStatus" class="nav-welcome"></span>
+        </div>
       </div>
-      <span id="authStatus" class="nav-welcome"></span>
+    </nav>
+    <div id="nav-backdrop" aria-hidden="true"></div>
+
+    <main class="corkboard" style="max-width: 1100px; margin: 2rem auto;">
+      <section class="sticky-note thumbtack" style="padding: 1.25rem;">
+        <h1 class="widget-title">
+          <i class="fa-solid fa-comment-dots" style="color: #c6534e;"></i>
+          Feedback
+        </h1>
+        <p>We value your feedback. Please share ideas and suggestions with the team.</p>
+      </section>
+    </main>
+
+    <div id="toast" class="toast toast--default" role="status" aria-live="polite" aria-atomic="true" hidden>
+      <div class="toast__icon" aria-hidden="true">i</div>
+      <div class="toast__content">
+        <div id="toastTitle" class="toast__title" hidden></div>
+        <div id="toastMessage" class="toast__message"></div>
+      </div>
+      <button id="toastClose" class="toast__close" type="button" aria-label="Close notification">×</button>
+      <div class="toast__progress"></div>
     </div>
-  </div>
-</nav>
-<div id="nav-backdrop" aria-hidden="true"></div>
+  </body>
+</html>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -164,6 +164,28 @@ document.addEventListener("DOMContentLoaded", () => {
     checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
 });
 
+
+async function updateNavTaskCounter() {
+    const counters = document.querySelectorAll(".item-counter");
+    if (!counters.length) return;
+
+    try {
+        const response = await fetch("/tasks", { credentials: "include" });
+        if (!response.ok) return;
+
+        const tasks = await response.json();
+        const activeCount = Array.isArray(tasks)
+            ? tasks.filter((task) => task.status === "active").length
+            : 0;
+
+        counters.forEach((el) => {
+            el.textContent = String(activeCount);
+        });
+    } catch (error) {
+        console.error("Error updating nav task counter:", error);
+    }
+}
+
 // Function to check if a user is currently logged in
 async function checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }) {
     const authSection = document.getElementById("auth-section");
@@ -223,6 +245,8 @@ async function checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, i
         if (mainSection) {
             fetchTasks(); // Automatically load tasks if user is logged in
         }
+
+        updateNavTaskCounter();
     } else {
         // Protected pages should send logged-out users to login instead of showing a blank shell.
         if (isProtectedPage) {

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -1,99 +1,90 @@
-<head>
-  <title>Stick A Pin</title>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="js/main.js" defer></script>
-  <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Stick A Pin</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="js/notification.js" defer></script>
+    <script src="js/main.js" defer></script>
+    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
+    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/stickies.css" />
+    <link rel="stylesheet" href="css/notification.css" />
+    <link rel="stylesheet" href="css/navbar.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
+    />
+  </head>
+  <body>
+    <header class="hero-header">
+      <h1>Stick A Pin</h1>
+    </header>
 
-  <!-- iOS home screen icon -->
-  <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <nav class="navbar">
+      <div class="nav-left">
+        <button class="nav__toggle" type="button" aria-label="Open menu" aria-controls="nav-drawer" aria-expanded="false">
+          <i class="fa-solid fa-bars" aria-hidden="true"></i>
+          <span class="sr-only">Menu</span>
+        </button>
 
-  <link rel="stylesheet" href="css/main.css" />
-  <link rel="stylesheet" href="css/stickies.css" />
-  <link rel="stylesheet" href="css/notification.css" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-    rel="stylesheet"
-  />
-
-  <!-- get rid of favicon error -->
-  <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-  <link rel="stylesheet" href="css/navbar.css" />
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
-  />
-  <!-- <script src="https://cdn.tailwindcss.com"></script> -->
-</head>
-<header class="hero-header">
-  <h1>Donezo</h1>
-</header>
-<nav class="navbar">
-  <div class="nav-left">
-    <button
-      class="nav__toggle"
-      type="button"
-      aria-label="Open menu"
-      aria-controls="nav-drawer"
-      aria-expanded="false"
-    >
-      <i class="fa-solid fa-bars" aria-hidden="true"></i>
-      <span class="sr-only">Menu</span>
-    </button>
-
-    <div class="logo-container">
-      <div class="logo-sticky">
-        <div class="thumbtack">
-          <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+        <div class="logo-container">
+          <div class="logo-sticky">
+            <div class="thumbtack">
+              <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+            </div>
+          </div>
+          <span class="brand-name">Stick A Pin</span>
         </div>
       </div>
-      <span class="brand-name">Stick A Pin</span>
-    </div>
-  </div>
 
-  <ul class="nav-links" id="nav-drawer">
-    <li><a href="/dashboard.html" class="nav-item">Board</a></li>
-    <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
-    <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
-    <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-    <li><a href="/profile-page.html" class="nav-item active">Profile</a></li>
-    <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
-  </ul>
+      <ul class="nav-links" id="nav-drawer">
+        <li><a href="/dashboard.html" class="nav-item">Board</a></li>
+        <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
+        <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
+        <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
+        <li><a href="/profile-page.html" class="nav-item active">Profile</a></li>
+        <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
+      </ul>
 
-  <div class="nav-right">
-    <div class="nav-status">
-      <div class="nav-tasks">
-        <span class="tasks-count item-counter"></span>
-        <span class="tasks-label-text">Tasks Left</span>
+      <div class="nav-right">
+        <div class="nav-status">
+          <div class="nav-tasks">
+            <span class="tasks-count item-counter"></span>
+            <span class="tasks-label-text">Tasks Left</span>
+          </div>
+          <span id="authStatus" class="nav-welcome"></span>
+        </div>
       </div>
-      <span id="authStatus" class="nav-welcome"></span>
-    </div>
-  </div>
-</nav>
-<div id="nav-backdrop" aria-hidden="true"></div>
+    </nav>
+    <div id="nav-backdrop" aria-hidden="true"></div>
 
-<div
-  id="toast"
-  class="toast toast--default"
-  role="status"
-  aria-live="polite"
-  aria-atomic="true"
-  hidden
->
-  <div class="toast__icon" aria-hidden="true">i</div>
-  <div class="toast__content">
-    <div id="toastTitle" class="toast__title" hidden></div>
-    <div id="toastMessage" class="toast__message"></div>
-  </div>
-  <button
-    id="toastClose"
-    class="toast__close"
-    type="button"
-    aria-label="Close notification"
-  >
-    ×
-  </button>
-  <div class="toast__progress"></div>
-</div>
+    <main class="corkboard" style="max-width: 1100px; margin: 2rem auto;">
+      <section class="sticky-note thumbtack" style="padding: 1.25rem;">
+        <h2 class="widget-title">
+          <i class="fa-solid fa-user" style="color: #c6534e;"></i>
+          Profile
+        </h2>
+        <p>Your profile details will appear here.</p>
+      </section>
+    </main>
+
+    <div id="toast" class="toast toast--default" role="status" aria-live="polite" aria-atomic="true" hidden>
+      <div class="toast__icon" aria-hidden="true">i</div>
+      <div class="toast__content">
+        <div id="toastTitle" class="toast__title" hidden></div>
+        <div id="toastMessage" class="toast__message"></div>
+      </div>
+      <button id="toastClose" class="toast__close" type="button" aria-label="Close notification">×</button>
+      <div class="toast__progress"></div>
+    </div>
+  </body>
+</html>

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -20,53 +20,59 @@
 
   <!-- get rid of favicon error -->
   <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-  <script
-    src="https://kit.fontawesome.com/a076d05399.js"
-    crossorigin="anonymous"
-  ></script>
+  <link rel="stylesheet" href="css/navbar.css" />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
+  />
   <!-- <script src="https://cdn.tailwindcss.com"></script> -->
 </head>
 <header class="hero-header">
   <h1>Donezo</h1>
 </header>
-<nav id="main-menu">
-  <!-- Logo/Site Name -->
-  <div id="site-logo">
-    <a href="/dashboard.html">
-      <h2>Board</h2>
-    </a>
-  </div>
-  <!-- Nav Links -->
-  <!-- Could be populated by a mongo db table with names and links -->
-  <div id="nav-links">
-    <div>
-      <a href="calendar-page.html"> <h3>Calendar</h3></a>
-    </div>
-    <h3>|</h3>
-    <div>
-      <a href="feedback-page.html"> <h3>Feedback</h3></a>
-    </div>
-    <h3>|</h3>
-    <div>
-      <a href="settings-page.html"> <h3>Settings</h3></a>
+<nav class="navbar">
+  <div class="nav-left">
+    <button
+      class="nav__toggle"
+      type="button"
+      aria-label="Open menu"
+      aria-controls="nav-drawer"
+      aria-expanded="false"
+    >
+      <i class="fa-solid fa-bars" aria-hidden="true"></i>
+      <span class="sr-only">Menu</span>
+    </button>
+
+    <div class="logo-container">
+      <div class="logo-sticky">
+        <div class="thumbtack">
+          <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+        </div>
+      </div>
+      <span class="brand-name">Stick A Pin</span>
     </div>
   </div>
 
-  <!-- Profile Section -->
-  <div id="profile-section">
-    <!-- Tasks Left -->
-    <div id="task-counter">
-      <h3 style="font-weight: 100">
-        Tasks Left: <span class="item-counter sticky-note thumbtack"></span>
-      </h3>
-    </div>
+  <ul class="nav-links" id="nav-drawer">
+    <li><a href="/dashboard.html" class="nav-item">Board</a></li>
+    <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
+    <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
+    <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
+    <li><a href="/profile-page.html" class="nav-item active">Profile</a></li>
+    <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
+  </ul>
 
-    <!-- Profile Button -->
-    <div id="profile-button">
-      <button id="logoutBtn">Log Out</button>
+  <div class="nav-right">
+    <div class="nav-status">
+      <div class="nav-tasks">
+        <span class="tasks-count item-counter"></span>
+        <span class="tasks-label-text">Tasks Left</span>
+      </div>
+      <span id="authStatus" class="nav-welcome"></span>
     </div>
   </div>
 </nav>
+<div id="nav-backdrop" aria-hidden="true"></div>
 
 <div
   id="toast"

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -1,43 +1,83 @@
-<nav class="navbar">
-  <div class="nav-left">
-    <button
-      class="nav__toggle"
-      type="button"
-      aria-label="Open menu"
-      aria-controls="nav-drawer"
-      aria-expanded="false"
-    >
-      <i class="fa-solid fa-bars" aria-hidden="true"></i>
-      <span class="sr-only">Menu</span>
-    </button>
-
-    <div class="logo-container">
-      <div class="logo-sticky">
-        <div class="thumbtack">
-          <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Stick A Pin</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="js/notification.js" defer></script>
+    <script src="js/main.js" defer></script>
+    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
+    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/stickies.css" />
+    <link rel="stylesheet" href="css/notification.css" />
+    <link rel="stylesheet" href="css/navbar.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
+    />
+  </head>
+  <body>
+    <nav class="navbar">
+      <div class="nav-left">
+        <button class="nav__toggle" type="button" aria-label="Open menu" aria-controls="nav-drawer" aria-expanded="false">
+          <i class="fa-solid fa-bars" aria-hidden="true"></i>
+          <span class="sr-only">Menu</span>
+        </button>
+        <div class="logo-container">
+          <div class="logo-sticky">
+            <div class="thumbtack">
+              <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+            </div>
+          </div>
+          <span class="brand-name">Stick A Pin</span>
         </div>
       </div>
-      <span class="brand-name">Stick A Pin</span>
-    </div>
-  </div>
-
-  <ul class="nav-links" id="nav-drawer">
-    <li><a href="/dashboard.html" class="nav-item">Board</a></li>
-    <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
-    <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
-    <li><a href="/settings-page.html" class="nav-item active">Settings</a></li>
-    <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
-    <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
-  </ul>
-
-  <div class="nav-right">
-    <div class="nav-status">
-      <div class="nav-tasks">
-        <span class="tasks-count item-counter"></span>
-        <span class="tasks-label-text">Tasks Left</span>
+      <ul class="nav-links" id="nav-drawer">
+        <li><a href="/dashboard.html" class="nav-item">Board</a></li>
+        <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
+        <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
+        <li><a href="/settings-page.html" class="nav-item active">Settings</a></li>
+        <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
+        <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
+      </ul>
+      <div class="nav-right">
+        <div class="nav-status">
+          <div class="nav-tasks">
+            <span class="tasks-count item-counter"></span>
+            <span class="tasks-label-text">Tasks Left</span>
+          </div>
+          <span id="authStatus" class="nav-welcome"></span>
+        </div>
       </div>
-      <span id="authStatus" class="nav-welcome"></span>
+    </nav>
+    <div id="nav-backdrop" aria-hidden="true"></div>
+
+    <main class="corkboard" style="max-width: 1100px; margin: 2rem auto;">
+      <section class="sticky-note blue thumbtack" style="padding: 1.25rem;">
+        <h1 class="widget-title">
+          <i class="fa-solid fa-gear" style="color: #c6534e;"></i>
+          Settings
+        </h1>
+        <p>Settings options will appear here. This page now uses the same app styling and responsive nav.</p>
+      </section>
+    </main>
+
+    <div id="toast" class="toast toast--default" role="status" aria-live="polite" aria-atomic="true" hidden>
+      <div class="toast__icon" aria-hidden="true">i</div>
+      <div class="toast__content">
+        <div id="toastTitle" class="toast__title" hidden></div>
+        <div id="toastMessage" class="toast__message"></div>
+      </div>
+      <button id="toastClose" class="toast__close" type="button" aria-label="Close notification">×</button>
+      <div class="toast__progress"></div>
     </div>
-  </div>
-</nav>
-<div id="nav-backdrop" aria-hidden="true"></div>
+  </body>
+</html>

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -1,47 +1,43 @@
-<nav id="main-menu">
-  <!-- Logo/Site Name -->
-  <div id="site-logo">
-    <a href="/dashboard.html">
-      <h2>Board</h2>
-    </a>
-  </div>
-  <!-- Nav Links -->
-  <!-- Could be populated by a mongo db table with names and links -->
-  <div id="nav-links">
-    <div>
-      <a href="calendar-page.html"> <h3>Calendar</h3></a>
-    </div>
-    <h3>|</h3>
-    <div>
-      <a href="feedback-page.html"> <h3>Feedback</h3></a>
-    </div>
-    <h3>|</h3>
-    <div>
-      <a href="settings-page.html"> <h3>Settings</h3></a>
-    </div>
-  </div>
+<nav class="navbar">
+  <div class="nav-left">
+    <button
+      class="nav__toggle"
+      type="button"
+      aria-label="Open menu"
+      aria-controls="nav-drawer"
+      aria-expanded="false"
+    >
+      <i class="fa-solid fa-bars" aria-hidden="true"></i>
+      <span class="sr-only">Menu</span>
+    </button>
 
-  <!-- Profile Section -->
-  <div id="profile-section">
-    <!-- Tasks Left -->
-    <div id="task-counter">
-      <h3 style="font-weight: 100">
-        Tasks Left: <span class="item-counter sticky-note thumbtack"></span>
-      </h3>
-    </div>
-
-    <!-- Profile Button -->
-    <div id="profile-button" class="profile-dropdown">
-      <button
-        class="profile-trigger sticky-note double-tape"
-        aria-haspopup="true"
-      >
-        <span id="authStatus"></span>
-        <span class="chevron">▾</span>
-      </button>
-      <div class="profile-menu">
-        <button id="logoutBtn">Log Out</button>
+    <div class="logo-container">
+      <div class="logo-sticky">
+        <div class="thumbtack">
+          <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+        </div>
       </div>
+      <span class="brand-name">Stick A Pin</span>
+    </div>
+  </div>
+
+  <ul class="nav-links" id="nav-drawer">
+    <li><a href="/dashboard.html" class="nav-item">Board</a></li>
+    <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
+    <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
+    <li><a href="/settings-page.html" class="nav-item active">Settings</a></li>
+    <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
+    <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
+  </ul>
+
+  <div class="nav-right">
+    <div class="nav-status">
+      <div class="nav-tasks">
+        <span class="tasks-count item-counter"></span>
+        <span class="tasks-label-text">Tasks Left</span>
+      </div>
+      <span id="authStatus" class="nav-welcome"></span>
     </div>
   </div>
 </nav>
+<div id="nav-backdrop" aria-hidden="true"></div>


### PR DESCRIPTION
### Motivation
- Unify navigation across the app by providing the same desktop + mobile drawer navigation used on the dashboard to the remaining app pages. 
- Replace the legacy `#main-menu` markup with the shared `.navbar` structure so mobile toggle and drawer behavior from `public/js/main.js` work consistently. 
- Preserve the exclusion request by not touching `index.html`, `login.html`, or `register.html`.

### Description
- Replaced legacy nav markup with the shared `.navbar` + `#nav-drawer` + `#nav-backdrop` structure in `public/calendar-page.html`, `public/feedback-page.html`, and `public/settings-page.html`. 
- Updated `public/profile-page.html` to use the shared `.navbar` structure and added the `css/navbar.css` and Font Awesome stylesheet includes so icons and the mobile toggle render correctly. 
- Marked the correct active nav item for each page (Board/Calendar/Feedback/Settings/Profile) and preserved the `#logoutBtn`/task counter placeholders used by the existing client-side logic. 

### Testing
- Verified presence/absence of old/new markup with `rg` checks for `"<nav id=\"main-menu\""` and `class="navbar"`, which confirmed replacements succeeded. 
- Launched a temporary static server with `python -m http.server 4173 --directory public` and captured a Playwright screenshot of `public/profile-page.html` to validate rendering of the updated navbar. 
- Ran repository validation steps including a file diff/stat to confirm only the intended `public/*.html` files were changed and the updates applied as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699495ed8c3883269d6f3370ba811cdc)