### PR TITLE
Make task completion only trigger from checkbox clicks

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -811,6 +811,8 @@ input:focus{
 }
 
 .task-text{
+  display: block;
+  margin-left: 2.1rem;
   line-height: 1.25;
   word-break: break-word;
   overflow-wrap: anywhere; /* keeps long words from pushing width */
@@ -852,7 +854,7 @@ input:focus{
   opacity: 1;
 }
 
-.checkbox-container .task-check:checked ~ .task-text{
+.task-item.is-completed .task-text{
   text-decoration: line-through;
   opacity: 0.6;
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -110,11 +110,11 @@
                       <i class="fa-solid fa-eraser" aria-hidden="true"></i>
                     </button>
                   </div>
-                  <label class="checkbox-container">
+                  <div class="checkbox-container">
                     <input type="checkbox" class="task-check" />
                     <span class="checkmark"></span>
-                    <span class="task-text"></span>
-                  </label>
+                  </div>
+                  <span class="task-text"></span>
                   <div class="task-meta">
                     <span class="task-due"></span>
                     <span class="task-effort">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -415,6 +415,7 @@ function updateTaskList(tasks) {
         }
         if (taskCheck) {
             taskCheck.checked = task.status === "completed";
+            taskItem?.classList.toggle("is-completed", taskCheck.checked);
 
             taskCheck.addEventListener("change", async () => {
                 const nextStatus = taskCheck.checked ? "completed" : "active";
@@ -428,16 +429,19 @@ function updateTaskList(tasks) {
 
                     if (updateResponse.ok) {
                         task.status = nextStatus;
+                        taskItem?.classList.toggle("is-completed", taskCheck.checked);
                         if (nextStatus === "completed") {
                             Toast.show({ message: "Task Completed! One step down, time for the next.", type: "success", duration: 4000 });
                         }
                         fetchTasks();
                     } else {
                         taskCheck.checked = !taskCheck.checked;
+                        taskItem?.classList.toggle("is-completed", taskCheck.checked);
                         console.error("Error updating task status");
                     }
                 } catch (error) {
                     taskCheck.checked = !taskCheck.checked;
+                    taskItem?.classList.toggle("is-completed", taskCheck.checked);
                     console.error("Task status update failed:", error);
                 }
             });


### PR DESCRIPTION
### Motivation

- The task description text was nested inside the checkbox label which caused clicks on the description to toggle completion unintentionally.  
- The goal is to ensure tasks are only marked completed when the checkbox is explicitly changed.

### Description

- Updated the task template in `public/dashboard.html` so the description is no longer inside the checkbox label and the checkbox container is a `div`, leaving the description in its own `span` (`.task-text`).
- Kept completion logic tied to the checkbox `change` event in `public/js/main.js` and added explicit toggling of a task-level `.is-completed` class on the `.task-item` when the checkbox state is set or rolled back on error.
- Adjusted styles in `public/css/main.css` by adding layout spacing for `.task-text` and switching the strike-through selector to use `.task-item.is-completed .task-text` so the visual state follows the checkbox only.

### Testing

- Ran `node --check public/js/main.js` which completed successfully.  
- Served the site with `python3 -m http.server 8000` and ran an automated Playwright script to capture a screenshot of `http://127.0.0.1:8000/public/dashboard.html` which completed successfully and produced `artifacts/dashboard-task-checkbox-fix.png`.
- No test failures were observed in the automated checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a0b610c883268287aa4140587686)