### PR TITLE
Fix mobile home-screen icon metadata for iOS/Android

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="js/notification.js" defer></script>
     <script src="js/main.js" defer></script>
-    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
-    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="css/stickies.css" />
     <link rel="stylesheet" href="css/notification.css" />
@@ -18,8 +20,7 @@
       href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-    <link
+        <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
     />

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -6,10 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="js/notification.js" defer></script>
     <script src="js/main.js" defer></script>
-    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
+    <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
 
     <!-- iOS home screen icon -->
-    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="css/stickies.css" />
     <link rel="stylesheet" href="css/notification.css" />
@@ -22,8 +24,7 @@
     />
 
     <!-- get rid of favicon error -->
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-    
+        
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="js/notification.js" defer></script>
     <script src="js/main.js" defer></script>
-    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
-    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="css/stickies.css" />
     <link rel="stylesheet" href="css/notification.css" />
@@ -18,8 +20,7 @@
       href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-    <link
+        <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
     />

--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="js/main.js" defer></script>
-    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
+    <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
 
     <!-- iOS home screen icon -->
-    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f5ecd7" />
 
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="css/stickies.css" />
@@ -21,8 +23,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <!-- get rid of favicon error -->
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-    <script
+        <script
       src="https://kit.fontawesome.com/a076d05399.js"
       crossorigin="anonymous"
     ></script>

--- a/public/login.html
+++ b/public/login.html
@@ -6,7 +6,10 @@
 
     <title>Stick A Pin</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
+    <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="css/stickies.css" />
     <link rel="stylesheet" href="css/notification.css" />
@@ -16,8 +19,7 @@
       href="https://fonts.googleapis.com/css2?family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-  </head>
+      </head>
   <body class="cork-page login-page">
     <main id="login-page" class="sticky-note double-tape">
       <div class="paper-content">

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="js/notification.js" defer></script>
     <script src="js/main.js" defer></script>
-    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
-    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="css/stickies.css" />
     <link rel="stylesheet" href="css/notification.css" />
@@ -18,8 +20,7 @@
       href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-    <link
+        <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
     />

--- a/public/register.html
+++ b/public/register.html
@@ -6,7 +6,10 @@
 
     <title>Stick A Pin</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
+    <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="css/stickies.css" />
     <link rel="stylesheet" href="css/notification.css" />
@@ -16,8 +19,7 @@
       href="https://fonts.googleapis.com/css2?family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-  </head>
+      </head>
   <body class="cork-page register-page">
     <main id="register-page" class="sticky-note double-tape">
       <div class="paper-content">

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="js/notification.js" defer></script>
     <script src="js/main.js" defer></script>
-    <link rel="icon" type="image/png" href="\assets\image\donezo-logo.png" />
-    <link rel="apple-touch-icon" href="donezo-logo.png" />
+    <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
     <link rel="stylesheet" href="css/stickies.css" />
     <link rel="stylesheet" href="css/notification.css" />
@@ -18,8 +20,7 @@
       href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
-    <link
+        <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
     />

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Stick A Pin",
+  "short_name": "Stick A Pin",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f5ecd7",
+  "theme_color": "#f5ecd7",
+  "icons": [
+    {
+      "src": "/assets/image/donezo-logo.png",
+      "sizes": "1536x1024",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Phones (especially iOS) rely on `apple-touch-icon` and a web manifest for home-screen bookmarks, but the app used a desktop favicon plus a blank data-URL fallback and Windows-style paths which prevented mobile browsers from resolving the logo. 
- The change aims to make the logo resolvable for saved bookmarks and installs on both iOS and Android by providing explicit mobile metadata and correct asset paths.

### Description
- Updated all HTML files in `public/` to use a valid web path for the favicon (`/assets/image/donezo-logo.png`) and removed the blank data-URL favicon that could override icon selection. 
- Added and standardized an `apple-touch-icon` with `sizes="180x180"` in each page so iOS has an explicit high-quality icon to use for home-screen bookmarks. 
- Added a web manifest at `public/site.webmanifest` with `icons`, `start_url`, `display`, `background_color`, and `theme_color`, and linked it from pages along with a `meta name="theme-color"` for Android/Chrome UI theming. 
- Replaced Windows-style backslashes in icon references and ensured the changes appear across `public/index.html`, `public/login.html`, `public/register.html`, `public/dashboard.html`, `public/calendar-page.html`, `public/feedback-page.html`, `public/profile-page.html`, and `public/settings-page.html`.

### Testing
- Verified presence of the new metadata using the search command `rg -n "rel=\"icon\"|apple-touch-icon|manifest|theme-color|data:;base64" public/*.html public/site.webmanifest`, which returned the updated lines and no remaining data-URL favicon entries. 
- Validated the manifest JSON syntax with `python -m json.tool public/site.webmanifest`, which completed successfully. 
- Programmatically inspected the logo PNG header to confirm it is a valid PNG and read its dimensions with a Python script, which reported the image as a PNG and returned expected dimensions (e.g. `1536x1024`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b951f13883268dddec925b19ae47)