### PR TITLE
Add slide-in task details panel with task actions

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -818,6 +818,21 @@ input:focus{
   overflow-wrap: anywhere; /* keeps long words from pushing width */
 }
 
+.task-details-trigger{
+  width: calc(100% - 2.1rem);
+  text-align: left;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  padding: 0;
+  cursor: pointer;
+}
+
+.task-details-trigger:hover{
+  color: #8B3A2E;
+}
+
 /* Meta row: due date + effort */
 .task-meta{
   display: flex;
@@ -1322,4 +1337,91 @@ input:focus{
     justify-content: flex-start;
     gap: 8px;
   }
+}
+
+
+.task-detail-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+  z-index: 899;
+}
+
+.task-detail-backdrop.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.task-detail-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(360px, 92vw);
+  height: 100vh;
+  background: #fff8e1;
+  border-left: 4px solid #000;
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.25);
+  transform: translateX(100%);
+  transition: transform 240ms ease;
+  z-index: 900;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.task-detail-panel.is-open {
+  transform: translateX(0);
+}
+
+.task-detail-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.task-detail-close {
+  border: 2px solid #E0C097;
+  background: transparent;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.task-detail-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.task-detail-actions .task-action-btn {
+  width: auto;
+  height: auto;
+  padding: 0.35rem 0.5rem;
+  gap: 0.3rem;
+}
+
+.task-detail-content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.task-detail-label {
+  margin: 0.75rem 0 0;
+  font-weight: 700;
+}
+
+.task-detail-value {
+  margin: 0;
+  min-height: 1.2rem;
+  word-break: break-word;
+}
+
+body.task-panel-open {
+  overflow: hidden;
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -100,22 +100,11 @@
               <ul class="task-list scrollable"></ul>
               <template id="task-template">
                 <li class="task-item">
-                  <div class="task-actions">
-                    <button type="button" class="task-action-btn big-three-btn" aria-label="Toggle Big 3 task" title="Toggle Big 3">
-                      <i class="fa-regular fa-star" style="color: rgba(237, 28, 28, 1.00);" aria-hidden="true"></i>
-                    </button>
-                    <button type="button" class="task-action-btn edit-btn" aria-label="Edit task" title="Edit">
-                      <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
-                    </button>
-                    <button type="button" class="task-action-btn delete-btn" aria-label="Delete task" title="Delete">
-                      <i class="fa-solid fa-eraser" aria-hidden="true"></i>
-                    </button>
-                  </div>
                   <label class="checkbox-container" aria-label="Mark task complete">
                     <input type="checkbox" class="task-check" />
                     <span class="checkmark"></span>
                   </label>
-                  <span class="task-text"></span>
+                  <button type="button" class="task-text task-details-trigger"></button>
                   <div class="task-meta">
                     <span class="task-due"></span>
                     <span class="task-effort">
@@ -248,6 +237,40 @@
       </button>
       <div class="toast__progress"></div>
     </div>
+
+    <aside id="task-detail-panel" class="task-detail-panel" aria-hidden="true">
+      <div class="task-detail-panel__header">
+        <h3>Task Details</h3>
+        <button id="taskDetailClose" class="task-detail-close" type="button" aria-label="Close task details">×</button>
+      </div>
+
+      <div class="task-detail-actions">
+        <button type="button" id="panelBigThreeBtn" class="task-action-btn big-three-btn" aria-label="Toggle Big 3 task">
+          <i class="fa-regular fa-star" style="color: rgba(237, 28, 28, 1.00);" aria-hidden="true"></i>
+          <span>Big 3</span>
+        </button>
+        <button type="button" id="panelEditBtn" class="task-action-btn">
+          <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
+          <span>Edit</span>
+        </button>
+        <button type="button" id="panelDeleteBtn" class="task-action-btn">
+          <i class="fa-solid fa-eraser" aria-hidden="true"></i>
+          <span>Delete</span>
+        </button>
+      </div>
+
+      <div class="task-detail-content">
+        <p class="task-detail-label">Task Description</p>
+        <p id="panelTaskDescription" class="task-detail-value"></p>
+
+        <p class="task-detail-label">Due Date</p>
+        <p id="panelTaskDueDate" class="task-detail-value"></p>
+
+        <p class="task-detail-label">Effort Level</p>
+        <p id="panelTaskEffort" class="task-detail-value"></p>
+      </div>
+    </aside>
+    <div id="task-detail-backdrop" class="task-detail-backdrop" aria-hidden="true"></div>
     
   </body>
 </html>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -372,6 +372,93 @@ function updateBigThreeWidget(tasks) {
     });
 }
 
+
+
+let activeTaskInPanel = null;
+
+function formatTaskDueDate(dueDate) {
+    if (!dueDate) return "No due date";
+    const date = new Date(dueDate);
+    return `Due: ${date.toLocaleDateString()}`;
+}
+
+function formatTaskEffortLevel(effortLevel) {
+    const safeEffort = Math.max(1, Math.min(5, parseInt(effortLevel, 10) || 3));
+    return `${safeEffort} / 5`;
+}
+
+function closeTaskDetailPanel() {
+    const panel = document.getElementById("task-detail-panel");
+    const backdrop = document.getElementById("task-detail-backdrop");
+    if (!panel || !backdrop) return;
+
+    panel.classList.remove("is-open");
+    panel.setAttribute("aria-hidden", "true");
+    backdrop.classList.remove("is-visible");
+    backdrop.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("task-panel-open");
+    activeTaskInPanel = null;
+}
+
+function wireTaskDetailPanel() {
+    const panel = document.getElementById("task-detail-panel");
+    const backdrop = document.getElementById("task-detail-backdrop");
+    const closeButton = document.getElementById("taskDetailClose");
+    if (!panel || !backdrop || !closeButton || panel.dataset.ready === "true") return;
+
+    const panelBigThreeButton = document.getElementById("panelBigThreeBtn");
+    const panelEditButton = document.getElementById("panelEditBtn");
+    const panelDeleteButton = document.getElementById("panelDeleteBtn");
+
+    closeButton.addEventListener("click", closeTaskDetailPanel);
+    backdrop.addEventListener("click", closeTaskDetailPanel);
+
+    document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape" && panel.classList.contains("is-open")) {
+            closeTaskDetailPanel();
+        }
+    });
+
+    panelBigThreeButton?.addEventListener("click", () => activeTaskInPanel?.toggleBigThree?.());
+    panelEditButton?.addEventListener("click", () => activeTaskInPanel?.editTask?.());
+    panelDeleteButton?.addEventListener("click", () => activeTaskInPanel?.deleteTask?.());
+
+    panel.dataset.ready = "true";
+}
+
+function openTaskDetailPanel(task, handlers) {
+    const panel = document.getElementById("task-detail-panel");
+    const backdrop = document.getElementById("task-detail-backdrop");
+    const descriptionEl = document.getElementById("panelTaskDescription");
+    const dueDateEl = document.getElementById("panelTaskDueDate");
+    const effortEl = document.getElementById("panelTaskEffort");
+    const panelBigThreeButton = document.getElementById("panelBigThreeBtn");
+    if (!panel || !backdrop || !descriptionEl || !dueDateEl || !effortEl || !panelBigThreeButton) return;
+
+    wireTaskDetailPanel();
+
+    descriptionEl.textContent = task.description || "No description";
+    dueDateEl.textContent = formatTaskDueDate(task.dueDate);
+    effortEl.textContent = formatTaskEffortLevel(task.effortLevel);
+
+    setBigThreeButtonState(panelBigThreeButton, task.isBigThree);
+    panelBigThreeButton.disabled = false;
+
+    activeTaskInPanel = {
+        ...handlers,
+        syncBigThree(nextValue) {
+            task.isBigThree = nextValue;
+            setBigThreeButtonState(panelBigThreeButton, nextValue);
+        }
+    };
+
+    panel.classList.add("is-open");
+    panel.setAttribute("aria-hidden", "false");
+    backdrop.classList.add("is-visible");
+    backdrop.setAttribute("aria-hidden", "false");
+    document.body.classList.add("task-panel-open");
+}
+
 // Function to update the UI with fetched tasks
 function updateTaskList(tasks) {
     const listOfTasks = document.querySelector(".task-list");
@@ -405,6 +492,7 @@ function updateTaskList(tasks) {
         const clone = taskTemplate.content.cloneNode(true);
         const taskItem = clone.querySelector(".task-item");
         const taskText = clone.querySelector(".task-text");
+        const taskDetailsTrigger = clone.querySelector(".task-details-trigger");
         const taskCheck = clone.querySelector(".task-check");
         const dueText = clone.querySelector(".task-due");
         const effortDots = clone.querySelectorAll(".task-effort .dot");
@@ -412,6 +500,7 @@ function updateTaskList(tasks) {
 
         if (taskItem && taskText) {
             taskText.textContent = task.description;
+            taskText.title = "Open task details";
         }
         if (taskCheck) {
             taskCheck.checked = task.status === "completed";
@@ -464,12 +553,11 @@ function updateTaskList(tasks) {
         }
         setBigThreeButtonState(bigThreeButton, task.isBigThree);
 
-        const editButton = clone.querySelector(".edit-btn");
-        const deleteButton = clone.querySelector(".delete-btn");
+        const panelBigThreeButton = document.getElementById("panelBigThreeBtn");
 
-        bigThreeButton?.addEventListener("click", async () => {
+        const toggleBigThree = async () => {
             const nextIsBigThree = !task.isBigThree;
-            bigThreeButton.disabled = true;
+            if (bigThreeButton) bigThreeButton.disabled = true;
 
             try {
                 const updateResponse = await fetch(`/tasks/${task._id}`, {
@@ -495,12 +583,14 @@ function updateTaskList(tasks) {
                 Toast.show({ message: "Could not update Big 3 status.", type: "error", duration: 3000 });
                 setBigThreeButtonState(bigThreeButton, task.isBigThree);
             } finally {
-                bigThreeButton.disabled = false;
+                if (bigThreeButton) bigThreeButton.disabled = false;
             }
-        });
+        };
+
+        bigThreeButton?.addEventListener("click", toggleBigThree);
 
         // Add event listener for editing a task
-        editButton?.addEventListener("click", async () => {
+        const editTask = async () => {
             const newDescription = prompt("Edit task description:", task.description);
             if (newDescription !== null && newDescription.trim() !== "") {
                 console.log("New Description:", newDescription);
@@ -521,10 +611,10 @@ function updateTaskList(tasks) {
                     console.error("Error updating task");
                 }
             }
-        });
+        };
 
         // Add event listener for deleting a task
-        deleteButton?.addEventListener("click", async () => {
+        const deleteTask = async () => {
             const confirmDelete = confirm("Are you sure you want to delete this task?");
             if (confirmDelete) {
                 const deleteResponse = await fetch(`/tasks/${task._id}`, {
@@ -539,6 +629,34 @@ function updateTaskList(tasks) {
                     console.error("Error deleting task");
                 }
             }
+        };
+
+        const rowBigThreeButton = clone.querySelector(".big-three-btn");
+        const rowEditButton = clone.querySelector(".edit-btn");
+        const rowDeleteButton = clone.querySelector(".delete-btn");
+
+        rowBigThreeButton?.addEventListener("click", toggleBigThree);
+        rowEditButton?.addEventListener("click", editTask);
+        rowDeleteButton?.addEventListener("click", deleteTask);
+
+        taskDetailsTrigger?.addEventListener("click", () => {
+            openTaskDetailPanel(task, {
+                toggleBigThree: async () => {
+                    panelBigThreeButton.disabled = true;
+                    await toggleBigThree();
+                    if (activeTaskInPanel) {
+                        activeTaskInPanel.syncBigThree(Boolean(task.isBigThree));
+                    }
+                    panelBigThreeButton.disabled = false;
+                },
+                editTask: async () => {
+                    await editTask();
+                },
+                deleteTask: async () => {
+                    await deleteTask();
+                    closeTaskDetailPanel();
+                }
+            });
         });
 
         listOfTasks.appendChild(clone);


### PR DESCRIPTION
### Motivation
- Provide a right-side slide-in panel so users can click a task description to view full task details (description, due date, effort) and act on the task without cluttering the task list.  
- Surface the `Big 3`, `Edit`, and `Delete` controls above the description inside the panel and include a top close button and backdrop for easy dismissal.

### Description
- Reworked the task template in `public/dashboard.html` to make the task description a clickable trigger button (`.task-details-trigger`) and added a new `<aside id="task-detail-panel">` panel plus `#task-detail-backdrop` for the sliding UI.  
- Added panel markup that includes the close button and the three action controls (`#panelBigThreeBtn`, `#panelEditBtn`, `#panelDeleteBtn`) and placeholders for `panelTaskDescription`, `panelTaskDueDate`, and `panelTaskEffort`.  
- Implemented client logic in `public/js/main.js`: helper formatters, `openTaskDetailPanel`, `closeTaskDetailPanel`, `wireTaskDetailPanel`, an `activeTaskInPanel` proxy, and changes inside `updateTaskList` to wire task-row actions to both the row buttons and the panel triggers so existing Big 3/edit/delete flows are reused.  
- Added CSS in `public/css/main.css` for `.task-details-trigger`, the backdrop, the right-side panel (`.task-detail-panel`), header/close button and spacing so the panel slides in with a backdrop and prevents body scrolling when open.

### Testing
- Ran syntax checks: `node --check public/js/main.js` (passed) and `node --check server.js` (passed).  
- Attempted to run the server with `node server.js` but the process exited due to an external MongoDB SRV DNS lookup failure (`querySrv ENOTFOUND _mongodb._tcp.cluster0.fyexz.mongodb.net`), which is unrelated to the front-end changes.  
- Attempted a headless browser screenshot via Playwright against a local file server to validate visuals, but the Playwright browser crashed (SIGSEGV) in this environment so no screenshot artifact was produced.  
- Changes committed: updated `public/dashboard.html`, `public/js/main.js`, and `public/css/main.css` and committed with message `Add sliding task detail panel for task actions`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c9f1a1e083269ebe5a7f5002a7cf)