### PR TITLE
chore(css): add section maps and clearer comments across stylesheets

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,7 +1,16 @@
 /* =========================================================
    main.css
-   - Everything EXCEPT sticky notes / tape / corkboard textures
-   - Core typography, layout, auth UI, dashboard widgets, tasks
+   - Core app foundation + page layout + dashboard/task widgets
+   - Responsive behavior for tablet/phone breakpoints
+   - Detailed sticky-note skins live in stickies.css
+
+   SECTION MAP
+   1) Global Base + Utilities
+   2) Auth & Landing Layout
+   3) Typography + Shared Components
+   4) Dashboard & Widgets
+   5) Responsive Overrides (Tablet / Phone)
+   6) Task Detail Side Panel
    ========================================================= */
 
 
@@ -1483,6 +1492,10 @@ input:focus{
 }
 
 
+/* =========================================================
+   TASK DETAIL SIDE PANEL
+   - Slide-in panel used to view/edit individual task details
+   ========================================================= */
 .task-detail-backdrop {
   position: fixed;
   inset: 0;

--- a/public/css/navbar.css
+++ b/public/css/navbar.css
@@ -1,3 +1,16 @@
+/* =========================================================
+   navbar.css
+   - Global top navigation styling
+   - Includes desktop layout and mobile drawer behavior
+
+   SECTION MAP
+   1) Accessibility Utility
+   2) Navbar Structure + Brand + Links
+   3) Status/Counter Area
+   4) Mobile Drawer + Breakpoints
+   ========================================================= */
+
+/* Accessibility-only text helper (screen readers) */
 .sr-only {
   position: absolute;
   width: 1px;
@@ -9,6 +22,7 @@
   border: 0;
 }
 
+/* Core navbar container */
 .navbar {
   position: relative;
   z-index: 1200;
@@ -141,6 +155,7 @@
   pointer-events: auto;
 }
 
+/* Tablet/coarse-pointer: convert links into slide-in drawer */
 @media (max-width: 1023px), (hover: none) and (pointer: coarse) {
   .navbar {
     gap: 10px;
@@ -215,6 +230,7 @@
   }
 }
 
+/* Phone breakpoint: tighter spacing and typography */
 @media (max-width: 767px) {
   .navbar {
     padding: 9px 10px;

--- a/public/css/notification.css
+++ b/public/css/notification.css
@@ -1,8 +1,20 @@
 /* =========================================================
+   notification.css
+   - Toast notification component and state variants
+
+   SECTION MAP
+   1) Toast Container + Layout
+   2) Toast Content Elements
+   3) Animations + Motion Preferences
+   4) Variant Themes (success/error/warning/info)
+   ========================================================= */
+
+/* =========================================================
    TOAST NOTIFICATIONS
    - Single toast component with type variants
    ========================================================= */
 
+/* Toast shell: fixed bottom-center notification */
 .toast {
   position: fixed;
   left: 50%;
@@ -89,7 +101,7 @@
   transition: transform linear;
 }
 
-/* Slide/fade animation */
+/* Entry/exit animation states */
 .toast.toast--show {
   animation: toastIn 180ms ease-out;
 }
@@ -106,13 +118,13 @@
   to   { opacity: 0; transform: translateX(-50%) translateY(10px); }
 }
 
-/* Reduced motion */
+/* Respect reduced motion preference */
 @media (prefers-reduced-motion: reduce) {
   .toast.toast--show, .toast.toast--hide { animation: none; }
   .toast__progress::before { transition: none; }
 }
 
-/* Type variants via CSS variables */
+/* Type variants via CSS custom properties */
 .toast--default { --toast-accent: #b98b5f; --toast-accent-soft: rgba(185,139,95,0.18); }
 .toast--success { --toast-accent: #2e8b57; --toast-accent-soft: rgba(46,139,87,0.16); }
 .toast--error   { --toast-accent: #b23b3b; --toast-accent-soft: rgba(178,59,59,0.16); }

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -1,3 +1,15 @@
+/* ============================================================
+   stickies.css
+   - Visual skin for corkboard + sticky notes + tape/thumbtack effects
+   - Decorative hand-drawn account dropdown treatment
+
+   SECTION MAP
+   1) Corkboard Surface + Grid Helpers
+   2) Sticky Note Base + Color Variants
+   3) Note Attachments (Thumbtack / Tape)
+   4) Interaction Layers (Rotation / Hover / Z-index)
+   5) Account Dropdown Styling
+   ============================================================ */
 
 /* ============================================================
    CORKBOARD BACKGROUND
@@ -335,7 +347,10 @@
 }
 
 
-/* Hand Drawn Styling */
+/* ============================================================
+   ACCOUNT DROPDOWN (HAND-DRAWN LOOK)
+   - Decorative dropdown trigger + menu treatment
+   ============================================================ */
 
 .account-dropdown {
     position: relative;
@@ -351,7 +366,7 @@
     cursor: pointer;
 }
 
-/* menu */
+/* Dropdown menu container */
 .account-menu {
     position: absolute;
     top: 120%;
@@ -367,25 +382,25 @@
     z-index: 100;
 }
 
-/* open state */
+/* Open state: menu visible */
 .account-dropdown.open .account-menu {
     display: block;
 }
 
-/* items */
+/* Menu items */
 .account-menu li {
     padding: 10px;
     border-radius: 12px 10px 14px 11px;
     cursor: pointer;
 }
 
-/* hover */
+/* Menu item hover state */
 .account-menu li:hover {
     background: #d86f67;
     color: white;
 }
 
-/* divider */
+/* Menu divider */
 .account-menu .divider {
     height: 1px;
     background: rgba(0,0,0,0.15);
@@ -393,7 +408,7 @@
     pointer-events: none;
 }
 
-/* logout styling */
+/* Logout emphasis styling */
 .account-menu .logout {
     color: #b33a35;
 }


### PR DESCRIPTION
### Motivation
- Improve maintainability by categorizing and documenting the CSS so areas like sticky notes, corkboard, navbar and mobile styling are easier to find. 
- Preserve the exact visual and interactive behavior while making it simpler for future contributors to navigate and update styles.

### Description
- Added high-level `SECTION MAP` headers and concise section comments to `public/css/main.css` to group global base, auth/landing, typography, dashboard/widgets, responsive overrides, and the task detail side panel. 
- Added a descriptive file header and organized section comments in `public/css/stickies.css` to group corkboard surface, sticky-note base, color variants, tape/thumbtack attachments, interactions, and account-dropdown styling. 
- Prepended a file header and improved accessibility and breakpoint comments in `public/css/navbar.css`, including a clearer `sr-only` note and labeled mobile drawer/phone breakpoint sections. 
- Added a file header and clarified animation/reduced-motion/variant comments in `public/css/notification.css` and labeled the toast container and progress bar sections. 
- All edits are comment and organizational changes only; selectors, properties and behavior were left functionally equivalent.

### Testing
- Ran `node --check server.js` to ensure the app entrypoint had no syntax issues, which completed successfully. 
- Verified the change set is limited to the four CSS files using `git diff -- public/css/main.css public/css/stickies.css public/css/navbar.css public/css/notification.css`, which showed only comment/documentation updates. 
- Committed the changes with a descriptive message (`docs(css): add section maps and clearer comments across stylesheets`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7253b265c8326878e646aff70dda0)