### PR TITLE
Add Clear Completed button to Task List and wire deletion logic

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -942,12 +942,15 @@ input:focus{
 }
 
 .clear-completed-button{
-  width: auto;
-  min-width: 0;
+  width: 2.2rem;
+  min-width: 2.2rem;
   margin: 0;
-  padding: 0.4rem 0.75rem;
-  font-size: 0.78rem;
-  line-height: 1.2;
+  padding: 0.4rem;
+  font-size: 0.9rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .clear-completed-button[disabled]{

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -928,6 +928,33 @@ input:focus{
 }
 
 /* Task sticky note wrapper */
+
+.task-list-header{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.task-list-header .widget-title{
+  margin-bottom: 0;
+}
+
+.clear-completed-button{
+  width: auto;
+  min-width: 0;
+  margin: 0;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.78rem;
+  line-height: 1.2;
+}
+
+.clear-completed-button[disabled]{
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
 .sticky-note.task-note{
   display: flex;
   flex-direction: column;

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -89,10 +89,19 @@
           <div>
             <!-- Task List -->
             <div id="task-list-widget" class="sticky-note thumbtack task-note">
-              <h2 class="widget-title highlight-on-parent-hover">
-                <i class="fa-solid fa-list" style="color: #c6534e"></i>
-                Task List
-              </h2>
+              <div class="task-list-header">
+                <h2 class="widget-title highlight-on-parent-hover">
+                  <i class="fa-solid fa-list" style="color: #c6534e"></i>
+                  Task List
+                </h2>
+                <button
+                  id="clear-completed-tasks-btn"
+                  class="paper-button clear-completed-button"
+                  type="button"
+                >
+                  Clear Completed
+                </button>
+              </div>
 
               <ul class="task-list scrollable"></ul>
               <template id="task-template">

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -98,8 +98,10 @@
                   id="clear-completed-tasks-btn"
                   class="paper-button clear-completed-button"
                   type="button"
+                  aria-label="Clear completed tasks"
+                  title="Clear completed tasks"
                 >
-                  Clear Completed
+                  <i class="fa-solid fa-trash-can" aria-hidden="true"></i>
                 </button>
               </div>
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -615,6 +615,11 @@ document.addEventListener("DOMContentLoaded", () => {
         taskForm.addEventListener("submit", submit);
     }
 
+    const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
+    if (clearCompletedButton) {
+        clearCompletedButton.addEventListener("click", clearCompletedTasks);
+    }
+
     checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
     initFocusMode();
 });
@@ -737,6 +742,56 @@ async function fetchTasks() {
     } else {
         console.error("Error fetching tasks:", tasks.error);
         alert("Please log in to see your tasks.");
+    }
+}
+
+async function clearCompletedTasks() {
+    const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
+
+    if (clearCompletedButton) {
+        clearCompletedButton.disabled = true;
+    }
+
+    try {
+        const response = await fetch("/tasks", { credentials: "include" });
+        const tasks = await parseApiResponse(response);
+
+        if (!response.ok) {
+            Toast.show({ message: tasks?.error || "Could not load tasks.", type: "error", duration: 3000 });
+            return;
+        }
+
+        const completedTasks = Array.isArray(tasks)
+            ? tasks.filter((task) => task.status === "completed")
+            : [];
+
+        if (completedTasks.length === 0) {
+            Toast.show({ message: "No completed tasks to clear.", type: "error", duration: 2200 });
+            return;
+        }
+
+        const deleteResults = await Promise.allSettled(
+            completedTasks.map((task) => fetch(`/tasks/${task._id}`, { method: "DELETE" }))
+        );
+
+        const deletedCount = deleteResults.filter((result) => result.status === "fulfilled" && result.value.ok).length;
+
+        if (deletedCount === completedTasks.length) {
+            Toast.show({ message: "Cleared completed tasks", type: "success", duration: 2500 });
+        } else if (deletedCount > 0) {
+            Toast.show({ message: `Cleared ${deletedCount} completed tasks. Some could not be deleted.`, type: "error", duration: 3500 });
+        } else {
+            Toast.show({ message: "Could not clear completed tasks.", type: "error", duration: 3000 });
+        }
+
+        fetchTasks();
+    } catch (error) {
+        console.error("Clearing completed tasks failed:", error);
+        Toast.show({ message: "Could not clear completed tasks.", type: "error", duration: 3000 });
+    } finally {
+        if (clearCompletedButton) {
+            clearCompletedButton.disabled = false;
+        }
     }
 }
 
@@ -1412,6 +1467,12 @@ function updateTaskList(tasks) {
 
     el.textContent = String(activeCount);
     });
+
+    const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
+    if (clearCompletedButton) {
+        const hasCompletedTasks = Array.isArray(tasks) && tasks.some((task) => task.status === "completed");
+        clearCompletedButton.disabled = !hasCompletedTasks;
+    }
 
     // If no tasks, show a friendly message
     if (tasks.length === 0) {


### PR DESCRIPTION
### Motivation
- Provide a convenient control at the top of the Task List widget to remove all tasks marked as completed in one action.

### Description
- Add a header row and `Clear Completed` button to the Task List widget in `public/dashboard.html` and position it to the right of the title.
- Add styles for the header and button in `public/css/main.css` including a disabled state so the control matches existing UI.
- Implement `clearCompletedTasks()` in `public/js/main.js`, wire the button click to this function, fetch tasks, delete completed tasks with `DELETE /tasks/:id`, show toast feedback for success/partial/failure results, and refresh the list via `fetchTasks()`.
- Update `updateTaskList` to automatically enable/disable the `Clear Completed` button depending on whether any completed tasks exist.

### Testing
- Ran `node --check public/js/main.js` to validate the JS syntax, which succeeded.
- Served the `public/` folder with `python -m http.server 4173 --directory public` and used a Playwright script to open `http://127.0.0.1:4173/dashboard.html` and capture a screenshot showing the new button, which completed successfully.
- Attempted to run `node server.js` to start the full app, which failed due to a missing `SESSION_SECRET` environment variable (expected configuration issue), so full server integration was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8d5dcc8408326b2a10fdc66560d28)