### PR TITLE
Add 'Clear Completed' button and implementation to Task List widget

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -928,6 +928,34 @@ input:focus{
 }
 
 /* Task sticky note wrapper */
+
+.task-list-header{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.task-list-header .widget-title{
+  margin-bottom: 0;
+}
+
+.clear-completed-button{
+  width: auto;
+  min-width: 0;
+  height: auto;
+  margin: 0;
+  padding: 0.38rem 0.72rem;
+  font-size: 0.78rem;
+  line-height: 1.2;
+}
+
+.clear-completed-button[disabled]{
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
 .sticky-note.task-note{
   display: flex;
   flex-direction: column;

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -89,10 +89,19 @@
           <div>
             <!-- Task List -->
             <div id="task-list-widget" class="sticky-note thumbtack task-note">
-              <h2 class="widget-title highlight-on-parent-hover">
-                <i class="fa-solid fa-list" style="color: #c6534e"></i>
-                Task List
-              </h2>
+              <div class="task-list-header">
+                <h2 class="widget-title highlight-on-parent-hover">
+                  <i class="fa-solid fa-list" style="color: #c6534e"></i>
+                  Task List
+                </h2>
+                <button
+                  id="clear-completed-tasks-btn"
+                  class="task-action-btn clear-completed-button"
+                  type="button"
+                >
+                  Clear Completed
+                </button>
+              </div>
 
               <ul class="task-list scrollable"></ul>
               <template id="task-template">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -615,6 +615,11 @@ document.addEventListener("DOMContentLoaded", () => {
         taskForm.addEventListener("submit", submit);
     }
 
+    const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
+    if (clearCompletedButton) {
+        clearCompletedButton.addEventListener("click", clearCompletedTasks);
+    }
+
     checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
     initFocusMode();
 });
@@ -737,6 +742,56 @@ async function fetchTasks() {
     } else {
         console.error("Error fetching tasks:", tasks.error);
         alert("Please log in to see your tasks.");
+    }
+}
+
+async function clearCompletedTasks() {
+    const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
+
+    if (clearCompletedButton) {
+        clearCompletedButton.disabled = true;
+    }
+
+    try {
+        const response = await fetch("/tasks", { credentials: "include" });
+        const tasks = await parseApiResponse(response);
+
+        if (!response.ok) {
+            Toast.show({ message: tasks?.error || "Could not load tasks.", type: "error", duration: 3000 });
+            return;
+        }
+
+        const completedTasks = Array.isArray(tasks)
+            ? tasks.filter((task) => task.status === "completed")
+            : [];
+
+        if (completedTasks.length === 0) {
+            Toast.show({ message: "No completed tasks to clear.", type: "error", duration: 2200 });
+            return;
+        }
+
+        const deleteResults = await Promise.allSettled(
+            completedTasks.map((task) => fetch(`/tasks/${task._id}`, { method: "DELETE" }))
+        );
+
+        const deletedCount = deleteResults.filter((result) => result.status === "fulfilled" && result.value.ok).length;
+
+        if (deletedCount === completedTasks.length) {
+            Toast.show({ message: "Cleared completed tasks", type: "success", duration: 2500 });
+        } else if (deletedCount > 0) {
+            Toast.show({ message: `Cleared ${deletedCount} completed tasks. Some could not be deleted.`, type: "error", duration: 3500 });
+        } else {
+            Toast.show({ message: "Could not clear completed tasks.", type: "error", duration: 3000 });
+        }
+
+        fetchTasks();
+    } catch (error) {
+        console.error("Clearing completed tasks failed:", error);
+        Toast.show({ message: "Could not clear completed tasks.", type: "error", duration: 3000 });
+    } finally {
+        if (clearCompletedButton) {
+            clearCompletedButton.disabled = false;
+        }
     }
 }
 
@@ -1412,6 +1467,12 @@ function updateTaskList(tasks) {
 
     el.textContent = String(activeCount);
     });
+
+    const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
+    if (clearCompletedButton) {
+        const hasCompletedTasks = Array.isArray(tasks) && tasks.some((task) => task.status === "completed");
+        clearCompletedButton.disabled = !hasCompletedTasks;
+    }
 
     // If no tasks, show a friendly message
     if (tasks.length === 0) {


### PR DESCRIPTION
### Motivation

- Provide an easy way for users to remove all completed tasks from the Task List to improve task management UX.
- Surface the action prominently in the widget header and make its enabled state reflect actual completed tasks.
- Ensure server-side deletes are performed safely and the UI is kept in sync after clearing.

### Description

- Added a header wrapper and a `Clear Completed` button to the task list widget in `public/dashboard.html` and moved the title into a `.task-list-header` container.
- Added styling for `.task-list-header` and `.clear-completed-button` in `public/css/main.css` including disabled state styling.
- Implemented `clearCompletedTasks()` in `public/js/main.js` which fetches `/tasks`, filters completed tasks, issues `DELETE` requests to `/tasks/:id` via `Promise.allSettled`, shows success/error toasts, disables the button during the operation, and refreshes the task list with `fetchTasks()`.
- Wired the button up on `DOMContentLoaded` and updated `updateTaskList()` to enable/disable the button based on whether any completed tasks are present.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8d5dcc8408326b2a10fdc66560d28)