### PR TITLE
Redesign Focus Mode into responsive three-column focus board

### DIFF
--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -1,33 +1,57 @@
-#focus-mode-widget {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  min-height: 420px;
-}
-
-.focus-mode-grid {
+#focus-mode-widget.focus-board {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 0.9rem;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 1.1fr) minmax(0, 1fr);
+  gap: 1.25rem;
+  min-height: 480px;
   align-items: stretch;
-  flex: 1;
-  min-height: 0;
 }
 
-.focus-mode-left,
-.focus-mode-right {
+.focus-column {
   min-width: 0;
   display: flex;
   flex-direction: column;
 }
 
-.focus-mode-left {
-  gap: 0.55rem;
-  overflow: hidden;
+.focus-column-left {
+  justify-content: flex-start;
 }
 
-.focus-mode-left > * {
-  min-width: 0;
+.focus-column-middle {
+  justify-content: center;
+}
+
+.focus-column-right {
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.focus-card {
+  width: 100%;
+}
+
+.focus-log-card,
+.focus-task-card,
+.focus-quote-card {
+  max-width: 100%;
+}
+
+.focus-log-card {
+  margin-top: 0.35rem;
+}
+
+.focus-session-card {
+  min-height: 430px;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  gap: 0.7rem;
+}
+
+.focus-phase-title {
+  margin: 0;
+  font-family: "Itim", serif;
+  font-size: clamp(1.2rem, 2vw, 1.6rem);
+  color: #5d4037;
 }
 
 #focus-mode-widget .focus-status {
@@ -37,8 +61,54 @@
   overflow-wrap: anywhere;
 }
 
-#focus-mode-widget .paper-field {
+.focus-session-center {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#focus-mode-widget .focus-controls {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: auto;
+}
+
+#focus-mode-widget .focus-controls .paper-button {
+  width: clamp(120px, 42%, 170px);
   margin: 0;
+  padding: 10px 0;
+}
+
+#focus-mode-widget .focus-controls button[hidden] {
+  display: none !important;
+}
+
+#focusStartBtn {
+  background: linear-gradient(180deg, #4fae58 0%, #33823c 100%);
+  color: #fff !important;
+}
+
+#focusStartBtn::before {
+  border-color: rgba(22, 67, 28, 0.42);
+}
+
+#focusStartBtn:hover:not(:disabled) {
+  background: linear-gradient(180deg, #58bd63 0%, #3b9346 100%);
+}
+
+#focusStopBtn {
+  color: #fff !important;
+}
+
+.focus-timer {
+  min-width: 4.2ch;
+  font-family: "Quantico", serif;
+  font-size: clamp(2.5rem, 5vw, 3.7rem);
+  color: #5d4037;
 }
 
 #focusTaskSelect {
@@ -47,7 +117,7 @@
 
 .focus-task-list {
   margin-top: 0.3rem;
-  max-height: 210px;
+  max-height: 240px;
   overflow-y: auto;
   overflow-x: hidden;
   padding-right: 0.2rem;
@@ -102,54 +172,6 @@
   opacity: 0.72;
 }
 
-#focus-mode-widget .focus-controls {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-top: auto;
-  padding-top: 0.45rem;
-}
-
-#focus-mode-widget .focus-controls .paper-button {
-  width: clamp(120px, 40%, 170px);
-  margin: 0;
-  padding: 10px 0;
-}
-
-#focus-mode-widget .focus-controls button[hidden] {
-  display: none !important;
-}
-
-#focusStartBtn {
-  background: linear-gradient(180deg, #4fae58 0%, #33823c 100%);
-  color: #fff !important;
-}
-
-#focusStartBtn::before {
-  border-color: rgba(22, 67, 28, 0.42);
-}
-
-#focusStartBtn:hover:not(:disabled) {
-  background: linear-gradient(180deg, #58bd63 0%, #3b9346 100%);
-}
-
-#focusStopBtn {
-  color: #fff !important;
-}
-
-.focus-timer {
-  min-width: 4.2ch;
-  font-family: "Quantico", serif;
-  font-size: 1.12rem;
-  color: #5d4037;
-}
-
-.focus-mode-right {
-  border-left: 1px dashed rgba(93, 64, 55, 0.35);
-  padding-left: 0.9rem;
-}
-
 .focus-log-title {
   margin: 0 0 0.35rem;
   font-family: "Itim", serif;
@@ -160,7 +182,7 @@
 .focus-log-body {
   margin-top: 0.15rem;
   overflow-y: auto;
-  max-height: 100%;
+  max-height: 280px;
   padding-right: 0.15rem;
 }
 
@@ -201,16 +223,71 @@
   opacity: 0.85;
 }
 
-@media (max-width: 1023px), (hover: none) and (pointer: coarse) {
-  .focus-mode-grid {
-    grid-template-columns: 1fr;
-    gap: 0.75rem;
+.focus-quote-card {
+  min-height: 130px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.focus-quote-text {
+  margin: 0;
+  text-align: center;
+  font-size: 1.05rem;
+  color: #5d4037;
+}
+
+@media (max-width: 1100px) {
+  #focus-mode-widget.focus-board {
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 1.1fr);
+    grid-template-areas:
+      "middle middle"
+      "left right";
   }
 
-  .focus-mode-right {
-    border-left: 0;
-    border-top: 1px dashed rgba(93, 64, 55, 0.35);
-    padding-left: 0;
-    padding-top: 0.65rem;
+  .focus-column-left {
+    grid-area: left;
+  }
+
+  .focus-column-middle {
+    grid-area: middle;
+  }
+
+  .focus-column-right {
+    grid-area: right;
+  }
+
+  .focus-session-card {
+    min-height: 360px;
+  }
+}
+
+@media (max-width: 768px), (hover: none) and (pointer: coarse) {
+  #focus-mode-widget.focus-board {
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+    min-height: 0;
+  }
+
+  .focus-column-middle {
+    order: 1;
+  }
+
+  .focus-column-left {
+    order: 2;
+  }
+
+  .focus-column-right {
+    order: 3;
+    gap: 0.85rem;
+  }
+
+  .focus-session-card {
+    min-height: 320px;
+  }
+
+  .focus-log-body,
+  .focus-task-list {
+    max-height: 220px;
   }
 }

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -74,20 +74,41 @@
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>
 
-    <main class="corkboard" style="max-width: 1100px; margin: 2rem auto">
-      <!-- Focus Mode -->
-      <div id="focus-mode-widget" class="sticky-note white tape">
-        <h2 class="widget-title highlight-on-parent-hover">
-          <i class="fa-solid fa-bullseye" style="color: #c6534e"></i>
-          Focus Mode
-        </h2>
+    <main class="corkboard" style="max-width: 1200px; margin: 0 auto">
+      <section id="focus-mode-widget" class="focus-board" aria-label="Focus mode board">
+        <div class="focus-column focus-column-left">
+          <article class="sticky-note yellow tape focus-card focus-log-card">
+            <h2 class="focus-log-title">Focus Log</h2>
+            <div id="focus-log-body" class="focus-log-body">
+              <p class="focus-log-note">
+                No focused tasks yet today. Start a focus session to track one.
+              </p>
+            </div>
+          </article>
+        </div>
 
-        <div class="focus-mode-grid">
-          <div class="focus-mode-left">
+        <div class="focus-column focus-column-middle">
+          <article class="sticky-note white tape focus-card focus-session-card">
+            <h2 class="focus-phase-title">Concentration Phase</h2>
             <p id="focus-status" class="focus-status">
               Pick a task and start a focus session.
             </p>
+            <div class="focus-session-center">
+              <span id="focusTimer" class="focus-timer" aria-live="polite">00:00</span>
+            </div>
+            <div class="focus-controls">
+              <button id="focusStartBtn" class="paper-button" type="button">
+                Start
+              </button>
+              <button id="focusStopBtn" class="paper-button" type="button" hidden disabled>
+                Stop
+              </button>
+            </div>
+          </article>
+        </div>
 
+        <div class="focus-column focus-column-right">
+          <article class="sticky-note blue tape focus-card focus-task-card">
             <div class="paper-field">
               <label id="focusTaskLabel" for="focusTaskSelect">Task</label>
               <select
@@ -102,30 +123,13 @@
                 aria-labelledby="focusTaskLabel"
               ></ul>
             </div>
+          </article>
 
-            <div class="focus-controls">
-              <button id="focusStartBtn" class="paper-button" type="button">
-                Start
-              </button>
-              <button id="focusStopBtn" class="paper-button" type="button" hidden disabled>
-                Stop
-              </button>
-              <span id="focusTimer" class="focus-timer" aria-live="polite"
-                >00:00</span
-              >
-            </div>
-          </div>
-
-          <div class="focus-mode-right">
-            <h3 class="focus-log-title">Focus Log</h3>
-            <div id="focus-log-body" class="focus-log-body">
-              <p class="focus-log-note">
-                No focused tasks yet today. Start a focus session to track one.
-              </p>
-            </div>
-          </div>
+          <article class="sticky-note pink tape focus-card focus-quote-card">
+            <p class="focus-quote-text">Put a encouraging quote here</p>
+          </article>
         </div>
-      </div>
+      </section>
     </main>
 
     <div


### PR DESCRIPTION
### Motivation
- Rework the Focus Mode UI to a modular, three-column board for clearer separation of session, tasks, and logs and to improve responsive behavior.
- Consolidate and simplify styles to make controls, timer, and cards consistent and easier to maintain.

### Description
- Replaced the old `#focus-mode-widget` markup with a `section` using the `focus-board` layout containing `.focus-column-left`, `.focus-column-middle`, and `.focus-column-right` and introduced card elements like `.focus-session-card`, `.focus-task-card`, `.focus-log-card`, and `.focus-quote-card` in `public/focus-page.html`.
- Moved the timer (`#focusTimer`) and start/stop controls (`#focusStartBtn`, `#focusStopBtn`) into the session card and reorganized the task list and log into their own cards.
- Rewrote `public/css/focus-page.css` to use a CSS Grid layout (new `grid-template-columns`) with updated gaps, sizing, typography, and button styles, added responsive `@media` rules for different breakpoints, and removed duplicated/obsolete selectors from the previous layout.
- Adjusted scrollable heights for `.focus-task-list` and `.focus-log-body` and introduced utility classes like `.focus-card`, `.focus-timer`, and `.focus-phase-title` for consistent styling.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9d77c81708326ac33307ecd73ebd3)