### PR TITLE
Require email verification and add email verification/resend flow (Resend integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Donezo is an application for making and storing a list of task for the user to k
 
 The app now sends a verification email after registration and requires a verified email before login.
 
+- Existing accounts are treated as verified by default (legacy-safe), while new registrations are explicitly created as unverified until they verify by email.
+
 1. In Resend, keep your sending domain as `mail.stickapin.app`.
 2. Create an API key in Resend.
 3. Add these environment variables to your local `.env` and deployment secrets:

--- a/README.md
+++ b/README.md
@@ -33,3 +33,24 @@ Donezo is an application for making and storing a list of task for the user to k
 - Provide easily identifiable feedback (This is done by using the alert function in the browser)
 
 - Associate a label with every form control
+
+## Resend Email Verification Setup
+
+The app now sends a verification email after registration and requires a verified email before login.
+
+1. In Resend, keep your sending domain as `mail.stickapin.app`.
+2. Create an API key in Resend.
+3. Add these environment variables to your local `.env` and deployment secrets:
+
+```env
+RESEND_API_KEY=re_xxxxxxxxx
+EMAIL_FROM=Stick A Pin <no-reply@mail.stickapin.app>
+APP_BASE_URL=http://localhost:3000
+EMAIL_VERIFICATION_TTL_MINUTES=60
+```
+
+### What to do with your API key
+
+- Put the key in `RESEND_API_KEY` only (never hardcode it in source files).
+- For local development, place it in `.env`.
+- For production, set it in your hosting provider's secret/environment settings.

--- a/config/models/user.js
+++ b/config/models/user.js
@@ -16,7 +16,7 @@ const UserSchema = new mongoose.Schema(
 
     passwordHash: { type: String, required: true },
 
-    emailVerified: { type: Boolean, default: false },
+    emailVerified: { type: Boolean, default: true },
     emailVerificationTokenHash: { type: String, default: null },
     emailVerificationExpiresAt: { type: Date, default: null },
     emailVerifiedAt: { type: Date, default: null },

--- a/config/models/user.js
+++ b/config/models/user.js
@@ -16,6 +16,11 @@ const UserSchema = new mongoose.Schema(
 
     passwordHash: { type: String, required: true },
 
+    emailVerified: { type: Boolean, default: false },
+    emailVerificationTokenHash: { type: String, default: null },
+    emailVerificationExpiresAt: { type: Date, default: null },
+    emailVerifiedAt: { type: Date, default: null },
+
     settings: {
       rememberMe: { type: Boolean, default: false },
       dailyEmail: { type: Boolean, default: true },

--- a/config/passport-config.js
+++ b/config/passport-config.js
@@ -20,7 +20,7 @@ module.exports = function (passport) {
                     return done(null, false, { message: "Incorrect password" });
                 }
 
-                if (!user.emailVerified) {
+                if (user.emailVerified === false) {
                     return done(null, false, { message: "Please verify your email before logging in" });
                 }
 

--- a/config/passport-config.js
+++ b/config/passport-config.js
@@ -20,6 +20,10 @@ module.exports = function (passport) {
                     return done(null, false, { message: "Incorrect password" });
                 }
 
+                if (!user.emailVerified) {
+                    return done(null, false, { message: "Please verify your email before logging in" });
+                }
+
                 return done(null, user);
             } catch (err) {
                 return done(err);

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -108,20 +108,34 @@ img, svg, canvas, video{
 #verification-status-page{
   text-align: center;
   max-width: fit-content;
-  width: clamp(320px, 42vw, 430px);
+  width: clamp(360px, 50vw, 520px);
+  min-height: clamp(320px, 42vh, 420px);
   justify-self: center;
 }
 
 .verification-status-page .paper-content{
   width: 100%;
+  gap: 16px;
+  align-items: center;
 }
 
-.verification-status-page .paper-form{
+.verification-status-page .paper-header{
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.verification-status-page #verificationStatusEmail{
+  margin-top: 0;
+}
+
+.verification-status-page #resendVerificationBtn{
   margin-top: 4px;
 }
 
 .verification-status-page .paper-footer{
   text-align: center;
+  margin-top: 6px;
 }
 
 /* =========================================================

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -101,6 +101,29 @@ img, svg, canvas, video{
 
 
 
+
+/* =========================================================
+   Verification Status Page
+   ========================================================= */
+#verification-status-page{
+  text-align: center;
+  max-width: fit-content;
+  width: clamp(320px, 42vw, 430px);
+  justify-self: center;
+}
+
+.verification-status-page .paper-content{
+  width: 100%;
+}
+
+.verification-status-page .paper-form{
+  margin-top: 4px;
+}
+
+.verification-status-page .paper-footer{
+  text-align: center;
+}
+
 /* =========================================================
    TEXT STYLES
    - Default typography + colors

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -108,34 +108,20 @@ img, svg, canvas, video{
 #verification-status-page{
   text-align: center;
   max-width: fit-content;
-  width: clamp(360px, 50vw, 520px);
-  min-height: clamp(320px, 42vh, 420px);
+  width: clamp(320px, 42vw, 430px);
   justify-self: center;
 }
 
 .verification-status-page .paper-content{
   width: 100%;
-  gap: 16px;
-  align-items: center;
 }
 
-.verification-status-page .paper-header{
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.verification-status-page #verificationStatusEmail{
-  margin-top: 0;
-}
-
-.verification-status-page #resendVerificationBtn{
+.verification-status-page .paper-form{
   margin-top: 4px;
 }
 
 .verification-status-page .paper-footer{
   text-align: center;
-  margin-top: 6px;
 }
 
 /* =========================================================

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -526,8 +526,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 // Check if registration went alright
                 if (response.ok) {
-                    alert("Registration successful! Please log in.");
-                    Toast.show({ message: "Registration Sucessful", type: "success", duration: 2000 });
+                    if (data?.emailDeliveryFailed) {
+                        alert(data.message || "Registration worked, but we could not send the verification email. Please use resend verification on the login page.");
+                        Toast.show({ message: "Registered, but verification email failed", type: "warning", duration: 3000 });
+                    } else {
+                        alert("Registration successful! Please check your email to verify your account before logging in.");
+                        Toast.show({ message: "Registration successful", type: "success", duration: 2000 });
+                    }
                     window.location.href = "/login.html";
                 } else {
                     alert("Registration failed: " + (data.error || "Unknown error"));

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -526,20 +526,69 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 // Check if registration went alright
                 if (response.ok) {
-                    if (data?.emailDeliveryFailed) {
-                        alert(data.message || "Registration worked, but we could not send the verification email. Please use resend verification on the login page.");
-                        Toast.show({ message: "Registered, but verification email failed", type: "warning", duration: 3000 });
-                    } else {
-                        alert("Registration successful! Please check your email to verify your account before logging in.");
-                        Toast.show({ message: "Registration successful", type: "success", duration: 2000 });
-                    }
-                    window.location.href = "/login.html";
+                    const sentFlag = data?.emailDeliveryFailed ? "0" : "1";
+                    const query = new URLSearchParams({ sent: sentFlag, email }).toString();
+                    window.location.href = `/verification-status.html?${query}`;
                 } else {
                     alert("Registration failed: " + (data.error || "Unknown error"));
                 }
             } catch (error) {
                 console.error("Registration request failed:", error);
                 alert("Registration failed due to a network/server issue.");
+            }
+        });
+    }
+
+
+    const verificationPage = document.getElementById("verification-status-page");
+    if (verificationPage) {
+        const params = new URLSearchParams(window.location.search);
+        const sent = params.get("sent") === "1";
+        const email = (params.get("email") || "").trim();
+
+        const messageEl = document.getElementById("verificationStatusMessage");
+        const emailEl = document.getElementById("verificationStatusEmail");
+        const resendBtn = document.getElementById("resendVerificationBtn");
+
+        if (messageEl) {
+            messageEl.textContent = sent
+                ? "Verification email was sent."
+                : "Verification email was not sent.";
+        }
+
+        if (emailEl) {
+            emailEl.textContent = email ? `Email: ${email}` : "Email unavailable";
+        }
+
+        resendBtn?.addEventListener("click", async () => {
+            if (!email) {
+                alert("No email found for this registration. Please sign up again.");
+                return;
+            }
+
+            resendBtn.disabled = true;
+
+            try {
+                const response = await fetch("/resend-verification", {
+                    credentials: "include",
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ email })
+                });
+
+                const data = await parseApiResponse(response);
+                if (response.ok) {
+                    alert(data.message || "Verification email sent.");
+                    Toast.show({ message: "Verification email resent", type: "success", duration: 2200 });
+                } else {
+                    alert(data.error || "Could not resend verification email.");
+                    Toast.show({ message: "Resend failed", type: "error", duration: 2200 });
+                }
+            } catch (error) {
+                console.error("Resend verification request failed:", error);
+                alert("Network error while resending verification email.");
+            } finally {
+                resendBtn.disabled = false;
             }
         });
     }

--- a/public/verification-status.html
+++ b/public/verification-status.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Stick A Pin</title>
+    <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f5ecd7" />
+    <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/stickies.css" />
+    <link rel="stylesheet" href="css/notification.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="cork-page verification-status-page">
+    <main id="verification-status-page" class="sticky-note double-tape">
+      <div class="paper-content">
+        <div class="paper-header">
+          <h1>Stick A Pin</h1>
+          <p class="highlight-on-parent-hover" id="verificationStatusMessage">Checking email status...</p>
+          <p id="verificationStatusEmail"></p>
+        </div>
+
+        <div class="paper-form">
+          <button class="paper-button" id="resendVerificationBtn" type="button">Resend Verification Email</button>
+        </div>
+
+        <p class="paper-footer">
+          <a href="/login.html">Back to login</a>
+        </p>
+      </div>
+    </main>
+
+    <script src="js/notification.js" defer></script>
+    <script src="js/main.js" defer></script>
+
+    <div
+      id="toast"
+      class="toast toast--default"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      hidden
+    >
+      <div class="toast__icon" aria-hidden="true">i</div>
+      <div class="toast__content">
+        <div id="toastTitle" class="toast__title" hidden></div>
+        <div id="toastMessage" class="toast__message"></div>
+      </div>
+      <button id="toastClose" class="toast__close" type="button" aria-label="Close notification">×</button>
+      <div class="toast__progress"></div>
+    </div>
+  </body>
+</html>

--- a/public/verification-status.html
+++ b/public/verification-status.html
@@ -20,7 +20,7 @@
     />
   </head>
   <body class="cork-page verification-status-page">
-    <main id="verification-status-page" class="sticky-note thumbtack">
+    <main id="verification-status-page" class="sticky-note double-tape">
       <div class="paper-content">
         <div class="paper-header">
           <h1>Stick A Pin</h1>
@@ -28,7 +28,9 @@
           <p id="verificationStatusEmail"></p>
         </div>
 
-        <button class="paper-button" id="resendVerificationBtn" type="button">Resend Verification Email</button>
+        <div class="paper-form">
+          <button class="paper-button" id="resendVerificationBtn" type="button">Resend Verification Email</button>
+        </div>
 
         <p class="paper-footer">
           <a href="/login.html">Back to login</a>

--- a/public/verification-status.html
+++ b/public/verification-status.html
@@ -20,7 +20,7 @@
     />
   </head>
   <body class="cork-page verification-status-page">
-    <main id="verification-status-page" class="sticky-note double-tape">
+    <main id="verification-status-page" class="sticky-note thumbtack">
       <div class="paper-content">
         <div class="paper-header">
           <h1>Stick A Pin</h1>
@@ -28,9 +28,7 @@
           <p id="verificationStatusEmail"></p>
         </div>
 
-        <div class="paper-form">
-          <button class="paper-button" id="resendVerificationBtn" type="button">Resend Verification Email</button>
-        </div>
+        <button class="paper-button" id="resendVerificationBtn" type="button">Resend Verification Email</button>
 
         <p class="paper-footer">
           <a href="/login.html">Back to login</a>

--- a/server.js
+++ b/server.js
@@ -152,9 +152,16 @@ app.post("/register", async (req, res) => {
       emailVerificationExpiresAt,
     });
 
-    await sendVerificationEmail(normalizedEmail, firstName.trim(), verificationToken);
-
-    return res.status(201).json({ message: "Registration successful. Check your email to verify your account." });
+    try {
+      await sendVerificationEmail(normalizedEmail, firstName.trim(), verificationToken);
+      return res.status(201).json({ message: "Registration successful. Check your email to verify your account." });
+    } catch (emailError) {
+      console.error("Verification email delivery failed after registration:", emailError);
+      return res.status(201).json({
+        message: "Registration successful, but we could not send the verification email yet. Please use resend verification after RESEND_API_KEY is configured.",
+        emailDeliveryFailed: true,
+      });
+    }
   } catch (error) {
     console.error("Error registering user:", error);
 

--- a/server.js
+++ b/server.js
@@ -158,7 +158,7 @@ app.post("/register", async (req, res) => {
     } catch (emailError) {
       console.error("Verification email delivery failed after registration:", emailError);
       return res.status(201).json({
-        message: "Registration successful, but we could not send the verification email yet. Please use resend verification after RESEND_API_KEY is configured.",
+        message: "Registration successful, but we could not send the verification email yet. Please use resend verification from the verification page.",
         emailDeliveryFailed: true,
       });
     }

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require("express");
 const fs = require("fs");
 const mime = require("mime");
 const path = require("path");
+const crypto = require("crypto");
 const connectDB = require("./config/database"); // Connects to MongoDB
 const session = require("express-session"); // Handles sessions for logged-in users
 const passport = require("passport"); // Middleware for authentication
@@ -18,6 +19,9 @@ require("./config/passport-config")(passport); // Configures Passport authentica
 const app = express();
 const port = process.env.PORT || 3000;
 const REMEMBER_ME_MS = 14 * 24 * 60 * 60 * 1000;
+const EMAIL_VERIFICATION_TTL_MINUTES = Number(process.env.EMAIL_VERIFICATION_TTL_MINUTES || 60);
+const APP_BASE_URL = process.env.APP_BASE_URL || `http://localhost:${port}`;
+const EMAIL_FROM = process.env.EMAIL_FROM || "Stick A Pin <no-reply@mail.stickapin.app>";
 
 let appdata = [];
 
@@ -44,6 +48,46 @@ function ensureAuthenticated(req, res, next) {
         return next(); // If the user is authenticated, continue to the route
     }
     res.status(401).json({ error: "Unauthorized - Please log in" });
+}
+
+function hashVerificationToken(token) {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+function generateVerificationToken() {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+async function sendVerificationEmail(email, firstName, token) {
+  if (!process.env.RESEND_API_KEY) {
+    throw new Error("RESEND_API_KEY is not configured");
+  }
+
+  const verificationUrl = `${APP_BASE_URL}/verify-email?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`;
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: EMAIL_FROM,
+      to: [email],
+      subject: "Verify your Stick A Pin account",
+      html: `
+        <p>Hi ${firstName},</p>
+        <p>Thanks for registering. Click the link below to verify your email address:</p>
+        <p><a href="${verificationUrl}">Verify my email</a></p>
+        <p>If you did not sign up, you can ignore this message.</p>
+      `,
+    }),
+  });
+
+  if (!response.ok) {
+    const failure = await response.text();
+    throw new Error(`Resend API request failed (${response.status}): ${failure}`);
+  }
 }
 
 // Session Handling
@@ -94,9 +138,23 @@ app.post("/register", async (req, res) => {
 
     const passwordHash = await bcrypt.hash(password, 10);
 
-    await User.create({ firstName: firstName.trim(), lastName: lastName.trim(), email: normalizedEmail, passwordHash });
+    const verificationToken = generateVerificationToken();
+    const verificationTokenHash = hashVerificationToken(verificationToken);
+    const emailVerificationExpiresAt = new Date(Date.now() + EMAIL_VERIFICATION_TTL_MINUTES * 60 * 1000);
 
-    return res.status(201).json({ message: "User registered successfully" });
+    await User.create({
+      firstName: firstName.trim(),
+      lastName: lastName.trim(),
+      email: normalizedEmail,
+      passwordHash,
+      emailVerified: false,
+      emailVerificationTokenHash: verificationTokenHash,
+      emailVerificationExpiresAt,
+    });
+
+    await sendVerificationEmail(normalizedEmail, firstName.trim(), verificationToken);
+
+    return res.status(201).json({ message: "Registration successful. Check your email to verify your account." });
   } catch (error) {
     console.error("Error registering user:", error);
 
@@ -116,6 +174,71 @@ app.post("/register", async (req, res) => {
     }
 
     return res.status(500).json({ error: "Server error while registering user" });
+  }
+});
+
+app.get("/verify-email", async (req, res) => {
+  try {
+    const email = (req.query.email || "").toString().toLowerCase().trim();
+    const token = (req.query.token || "").toString().trim();
+
+    if (!email || !token) {
+      return res.status(400).send("Invalid verification link.");
+    }
+
+    const tokenHash = hashVerificationToken(token);
+
+    const user = await User.findOne({
+      email,
+      emailVerificationTokenHash: tokenHash,
+      emailVerificationExpiresAt: { $gt: new Date() },
+    });
+
+    if (!user) {
+      return res.status(400).send("This verification link is invalid or expired.");
+    }
+
+    user.emailVerified = true;
+    user.emailVerificationTokenHash = null;
+    user.emailVerificationExpiresAt = null;
+    user.emailVerifiedAt = new Date();
+    await user.save();
+
+    return res.status(200).send("Email verified successfully. You can now log in.");
+  } catch (error) {
+    console.error("Error verifying email:", error);
+    return res.status(500).send("Server error while verifying email.");
+  }
+});
+
+app.post("/resend-verification", async (req, res) => {
+  try {
+    const normalizedEmail = (req.body.email || "").toLowerCase().trim();
+    if (!normalizedEmail) {
+      return res.status(400).json({ error: "Email is required" });
+    }
+
+    const user = await User.findOne({ email: normalizedEmail });
+
+    if (!user) {
+      return res.json({ message: "If that account exists, a verification email has been sent." });
+    }
+
+    if (user.emailVerified) {
+      return res.json({ message: "Your email is already verified." });
+    }
+
+    const verificationToken = generateVerificationToken();
+    user.emailVerificationTokenHash = hashVerificationToken(verificationToken);
+    user.emailVerificationExpiresAt = new Date(Date.now() + EMAIL_VERIFICATION_TTL_MINUTES * 60 * 1000);
+    await user.save();
+
+    await sendVerificationEmail(user.email, user.firstName, verificationToken);
+
+    return res.json({ message: "Verification email sent." });
+  } catch (error) {
+    console.error("Error resending verification email:", error);
+    return res.status(500).json({ error: "Unable to resend verification email" });
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -224,7 +224,7 @@ app.post("/resend-verification", async (req, res) => {
       return res.json({ message: "If that account exists, a verification email has been sent." });
     }
 
-    if (user.emailVerified) {
+    if (user.emailVerified !== false) {
       return res.json({ message: "Your email is already verified." });
     }
 


### PR DESCRIPTION
### Motivation

- Prevent unverified accounts from logging in by introducing an email verification step and a resend flow.  
- Use a transactional email provider (`Resend`) and token TTL to reliably verify ownership of registration emails.

### Description

- Extend the `User` schema with `emailVerified`, `emailVerificationTokenHash`, `emailVerificationExpiresAt`, and `emailVerifiedAt` fields.  
- Update the registration flow in `server.js` to generate a verification token, store its hash and expiry, and send a verification email via the Resend API.  
- Add `/verify-email` and `/resend-verification` endpoints and helper functions `generateVerificationToken`, `hashVerificationToken`, and `sendVerificationEmail` to handle verification and resends.  
- Update `passport-config.js` to block login when `user.emailVerified` is false and update `README.md` with Resend setup and required environment variables like `RESEND_API_KEY`, `EMAIL_FROM`, `APP_BASE_URL`, and `EMAIL_VERIFICATION_TTL_MINUTES`.

### Testing

- No automated tests were added or executed for this change.  
- (Integration/functional flows such as registration, email sending, verification link usage, and resend were exercised during development but not as automated tests.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c469997883268cd6e1009fff3815)