### PR TITLE
Use dynamic base URL for verification and reset email links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The app now sends a verification email after registration and requires a verifie
 ```env
 RESEND_API_KEY=re_xxxxxxxxx
 EMAIL_FROM=Stick A Pin <no-reply@mail.stickapin.app>
-APP_BASE_URL=http://localhost:3000
+APP_BASE_URL=http://localhost:3000  # optional; set explicitly to your deployed app URL in production
 EMAIL_VERIFICATION_TTL_MINUTES=60
 PASSWORD_RESET_TTL_MINUTES=30
 ```
@@ -59,4 +59,4 @@ PASSWORD_RESET_TTL_MINUTES=30
 - For production, set it in your hosting provider's secret/environment settings.
 
 
-Forgot password flow uses `POST /forgot-password` and `POST /reset-password` with reset links sent through Resend.
+Forgot password flow uses `POST /forgot-password` and `POST /reset-password` with reset links sent through Resend. If `APP_BASE_URL` is unset, links are derived from the incoming request host/protocol.

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -111,6 +111,26 @@ img, svg, canvas, video{
 
 
 
+
+.verification-success-page .paper-content{
+  width: 100%;
+  text-align: center;
+}
+
+.verification-success-page h1{
+  font-size: clamp(24px, 4.6vw, 38px);
+  text-decoration: none;
+}
+
+.verification-success-page #verificationSuccessMessage{
+  margin: 0;
+  width: 100%;
+  text-align: center;
+}
+
+.verification-success-page .paper-footer{
+  text-align: center;
+}
 /* =========================================================
    Verification Status Page
    ========================================================= */

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -100,7 +100,8 @@ img, svg, canvas, video{
 }
 
 #forgot-password-page,
-#reset-password-page{
+#reset-password-page,
+#verification-success-page{
   text-align: center;
   max-width: fit-content;
   width: clamp(300px, 40vw, 420px);

--- a/public/verification-success.html
+++ b/public/verification-success.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Email Verified | Stick A Pin</title>
+    <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/stickies.css" />
+  </head>
+  <body class="cork-page verification-success-page">
+    <main id="verification-success-page" class="sticky-note thumbtack">
+      <div class="paper-content">
+        <h1>Email Verification</h1>
+        <p id="verificationSuccessMessage">Verification successful.</p>
+        <p class="paper-footer"><a href="/login.html">Go to Log In</a></p>
+      </div>
+    </main>
+  </body>
+</html>

--- a/server.js
+++ b/server.js
@@ -260,7 +260,7 @@ app.get("/verify-email", async (req, res) => {
     user.emailVerifiedAt = new Date();
     await user.save();
 
-    return res.status(200).send("Email verified successfully. You can now log in.");
+    return res.redirect("/verification-success.html");
   } catch (error) {
     console.error("Error verifying email:", error);
     return res.status(500).send("Server error while verifying email.");

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ const port = process.env.PORT || 3000;
 const REMEMBER_ME_MS = 14 * 24 * 60 * 60 * 1000;
 const EMAIL_VERIFICATION_TTL_MINUTES = Number(process.env.EMAIL_VERIFICATION_TTL_MINUTES || 60);
 const PASSWORD_RESET_TTL_MINUTES = Number(process.env.PASSWORD_RESET_TTL_MINUTES || 30);
-const APP_BASE_URL = process.env.APP_BASE_URL || `http://localhost:${port}`;
+const APP_BASE_URL = process.env.APP_BASE_URL;
 const EMAIL_FROM = process.env.EMAIL_FROM || "Stick A Pin <no-reply@mail.stickapin.app>";
 
 let appdata = [];
@@ -59,12 +59,12 @@ function generateVerificationToken() {
   return crypto.randomBytes(32).toString("hex");
 }
 
-async function sendVerificationEmail(email, firstName, token) {
+async function sendVerificationEmail(email, firstName, token, baseUrl) {
   if (!process.env.RESEND_API_KEY) {
     throw new Error("RESEND_API_KEY is not configured");
   }
 
-  const verificationUrl = `${APP_BASE_URL}/verify-email?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`;
+  const verificationUrl = `${baseUrl}/verify-email?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`;
 
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
@@ -91,12 +91,12 @@ async function sendVerificationEmail(email, firstName, token) {
   }
 }
 
-async function sendPasswordResetEmail(email, firstName, token) {
+async function sendPasswordResetEmail(email, firstName, token, baseUrl) {
   if (!process.env.RESEND_API_KEY) {
     throw new Error("RESEND_API_KEY is not configured");
   }
 
-  const resetUrl = `${APP_BASE_URL}/reset-password.html?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`;
+  const resetUrl = `${baseUrl}/reset-password.html?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`;
 
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
@@ -121,6 +121,22 @@ async function sendPasswordResetEmail(email, firstName, token) {
     const failure = await response.text();
     throw new Error(`Resend API request failed (${response.status}): ${failure}`);
   }
+}
+
+function resolveBaseUrl(req) {
+  if (APP_BASE_URL) {
+    return APP_BASE_URL.replace(/\/$/, "");
+  }
+
+  const forwardedProto = req?.headers?.["x-forwarded-proto"];
+  const protocol = (forwardedProto ? forwardedProto.split(",")[0] : req?.protocol || "http").trim();
+  const host = req?.get?.("host") || req?.headers?.host;
+
+  if (host) {
+    return `${protocol}://${host}`.replace(/\/$/, "");
+  }
+
+  return `http://localhost:${port}`;
 }
 
 // Session Handling
@@ -186,7 +202,7 @@ app.post("/register", async (req, res) => {
     });
 
     try {
-      await sendVerificationEmail(normalizedEmail, firstName.trim(), verificationToken);
+      await sendVerificationEmail(normalizedEmail, firstName.trim(), verificationToken, resolveBaseUrl(req));
       return res.status(201).json({ message: "Registration successful. Check your email to verify your account." });
     } catch (emailError) {
       console.error("Verification email delivery failed after registration:", emailError);
@@ -273,7 +289,7 @@ app.post("/resend-verification", async (req, res) => {
     user.emailVerificationExpiresAt = new Date(Date.now() + EMAIL_VERIFICATION_TTL_MINUTES * 60 * 1000);
     await user.save();
 
-    await sendVerificationEmail(user.email, user.firstName, verificationToken);
+    await sendVerificationEmail(user.email, user.firstName, verificationToken, resolveBaseUrl(req));
 
     return res.json({ message: "Verification email sent." });
   } catch (error) {
@@ -303,7 +319,7 @@ app.post("/forgot-password", async (req, res) => {
     user.passwordResetRequestedAt = new Date();
     await user.save();
 
-    await sendPasswordResetEmail(user.email, user.firstName, resetToken);
+    await sendPasswordResetEmail(user.email, user.firstName, resetToken, resolveBaseUrl(req));
 
     return res.json({ message: "If that account exists, a password reset email has been sent." });
   } catch (error) {


### PR DESCRIPTION
### Motivation

- Ensure verification and password reset links are correct when `APP_BASE_URL` is not provided and the app runs behind proxies or on different hosts. 
- Avoid hardcoding `http://localhost:3000` as the canonical base URL so deployed environments can derive URLs from the incoming request.

### Description

- Stop defaulting `APP_BASE_URL` to `http://localhost:<port>` and read it only from `process.env.APP_BASE_URL`.
- Add `resolveBaseUrl(req)` which derives a base URL from `APP_BASE_URL` or the request (`x-forwarded-proto`, `req.protocol`, and `Host`) and falls back to `http://localhost:<port>`.
- Update `sendVerificationEmail` and `sendPasswordResetEmail` to accept a `baseUrl` parameter and use it to construct email action links.
- Pass `resolveBaseUrl(req)` into email-sending calls from `/register`, `/resend-verification`, and `/forgot-password`, and update `README.md` to document the optional `APP_BASE_URL` and fallback behavior.

### Testing

- Ran `npm run lint` locally and the linter passed.
- Ran the project test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e75753748326a9067f7485a7d6cf)