### PR TITLE
Fix Vercel crash caused by duplicate rateLimit declaration

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,6 @@ const bcrypt = require("bcryptjs"); // Used to hash passwords
 const User = require("./config/models/user"); // User model for the database
 const Task = require("./config/models/task"); // Task model for the database
 const FocusSession = require("./config/models/focusSession"); // FocusSession model for tracking focus sessions
-const rateLimit = require("express-rate-limit");
 const rateLimit = require("express-rate-limit"); // Rate limiting middleware
 const MongoStore = require("connect-mongo").default; // Store sessions in MongoDB
 


### PR DESCRIPTION
### Motivation
- Prevent the Node.js startup `SyntaxError: Identifier 'rateLimit' has already been declared'` that produced 500s on preview deployments; this was caused by a duplicate import rather than a missing package since `express-rate-limit` is already in `package.json`.

### Description
- Remove the duplicated `const rateLimit = require("express-rate-limit")` line from `server.js` so `rateLimit` is declared only once at startup.

### Testing
- Ran `node --check server.js` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d2d39fc883268975210305b9f33c)