### PR TITLE
Add focus-task filter tabs and filtering logic in Focus mode

### DIFF
--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -115,6 +115,38 @@
   display: none !important;
 }
 
+
+
+.focus-task-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+  margin-top: 0.35rem;
+}
+
+.focus-task-tab {
+  border: 1px solid rgba(93, 64, 55, 0.35);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.42);
+  color: #5d4037;
+  font: inherit;
+  font-size: 0.82rem;
+  line-height: 1.2;
+  padding: 0.32rem 0.3rem;
+  cursor: pointer;
+}
+
+.focus-task-tab.is-active {
+  border-color: rgba(198, 83, 78, 0.7);
+  background: rgba(247, 204, 220, 0.55);
+  color: #8b3a2e;
+  font-weight: 700;
+}
+
+.focus-task-tab:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
 .focus-task-list {
   margin-top: 0.3rem;
   max-height: 240px;

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -110,7 +110,12 @@
         <div class="focus-column focus-column-right">
           <article class="sticky-note blue tape focus-card focus-task-card">
             <div class="paper-field">
-              <label id="focusTaskLabel" for="focusTaskSelect">Task</label>
+              <label id="focusTaskLabel" for="focusTaskSelect">What should we focus on right now?</label>
+              <div class="focus-task-tabs" role="tablist" aria-label="Filter focus tasks">
+                <button id="focusTabBigThree" class="focus-task-tab is-active" type="button" role="tab" aria-selected="true" aria-controls="focusTaskList" data-filter="big-three">Big 3</button>
+                <button id="focusTabTaskList" class="focus-task-tab" type="button" role="tab" aria-selected="false" aria-controls="focusTaskList" data-filter="task-list">Task List</button>
+                <button id="focusTabEffort" class="focus-task-tab" type="button" role="tab" aria-selected="false" aria-controls="focusTaskList" data-filter="effort">Effort</button>
+              </div>
               <select
                 id="focusTaskSelect"
                 aria-label="Select a task to focus on"

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -20,7 +20,9 @@ const focusState = {
     taskId: null,
     sessionId: null,
     startedAt: null,
-    timerIntervalId: null
+    timerIntervalId: null,
+    filter: "big-three",
+    allTasks: []
 };
 
 function formatFocusDuration(totalSeconds) {
@@ -58,6 +60,65 @@ function stopFocusTimer() {
     }
 }
 
+function getFocusTasksByFilter(tasks, filter) {
+    const activeTasks = Array.isArray(tasks)
+        ? tasks.filter((task) => task.status === "active")
+        : [];
+
+    if (filter === "big-three") {
+        return activeTasks.filter((task) => Boolean(task.isBigThree)).slice(0, 3);
+    }
+
+    if (filter === "effort") {
+        return [...activeTasks].sort((a, b) => {
+            const effortA = Number(a?.effortLevel) || 5;
+            const effortB = Number(b?.effortLevel) || 5;
+            if (effortA !== effortB) return effortA - effortB;
+
+            const createdA = new Date(a?.createdAt || 0).getTime();
+            const createdB = new Date(b?.createdAt || 0).getTime();
+            return createdB - createdA;
+        });
+    }
+
+    return [...activeTasks].sort((a, b) => {
+        const createdA = new Date(a?.createdAt || 0).getTime();
+        const createdB = new Date(b?.createdAt || 0).getTime();
+        return createdB - createdA;
+    });
+}
+
+function updateFocusFilterTabs(selectedFilter, { running = false } = {}) {
+    const tabButtons = document.querySelectorAll(".focus-task-tab");
+    if (!tabButtons.length) return;
+
+    tabButtons.forEach((buttonEl) => {
+        const isActive = buttonEl.dataset.filter === selectedFilter;
+        buttonEl.classList.toggle("is-active", isActive);
+        buttonEl.setAttribute("aria-selected", isActive ? "true" : "false");
+        buttonEl.disabled = Boolean(running);
+    });
+}
+
+function bindFocusFilterTabs() {
+    const tabButtons = document.querySelectorAll(".focus-task-tab");
+    if (!tabButtons.length) return;
+
+    tabButtons.forEach((buttonEl) => {
+        buttonEl.addEventListener("click", () => {
+            if (focusState.taskId) return;
+
+            const filter = buttonEl.dataset.filter || "big-three";
+            if (filter === focusState.filter) return;
+
+            focusState.filter = filter;
+            updateFocusTaskOptions(focusState.allTasks);
+        });
+    });
+
+    updateFocusFilterTabs(focusState.filter, { running: Boolean(focusState.taskId) });
+}
+
 function updateFocusModeControls({ running, hasTask } = {}) {
     const selectEl = document.getElementById("focusTaskSelect");
     const taskListEl = document.getElementById("focusTaskList");
@@ -74,6 +135,9 @@ function updateFocusModeControls({ running, hasTask } = {}) {
             buttonEl.disabled = Boolean(running);
         });
     }
+
+    updateFocusFilterTabs(focusState.filter, { running: Boolean(running) });
+
     if (startBtn) {
         startBtn.hidden = Boolean(running);
         startBtn.disabled = Boolean(running) || !canStart;
@@ -100,15 +164,13 @@ function updateFocusTaskOptions(tasks) {
     const taskListEl = document.getElementById("focusTaskList");
     if (!selectEl) return;
 
-    const activeTasks = Array.isArray(tasks)
-        ? tasks.filter((task) => task.status === "active")
-        : [];
-
     const previousValue = selectEl.value;
+    const filteredTasks = getFocusTasksByFilter(tasks, focusState.filter);
+
     selectEl.innerHTML = "";
     if (taskListEl) taskListEl.innerHTML = "";
 
-    if (activeTasks.length === 0) {
+    if (filteredTasks.length === 0) {
         const option = document.createElement("option");
         option.value = "";
         option.textContent = "No active tasks";
@@ -125,7 +187,7 @@ function updateFocusTaskOptions(tasks) {
         return;
     }
 
-    activeTasks.forEach((task) => {
+    filteredTasks.forEach((task) => {
         const option = document.createElement("option");
         const taskId = String(task._id);
         option.value = taskId;
@@ -208,15 +270,18 @@ function updateFocusTaskOptions(tasks) {
         }
     });
 
-    if (previousValue && activeTasks.some((task) => String(task._id) === previousValue)) {
+    if (previousValue && filteredTasks.some((task) => String(task._id) === previousValue)) {
         selectEl.value = previousValue;
     }
 
-    if (!selectEl.value && activeTasks.length > 0) {
-        selectEl.value = String(activeTasks[0]._id);
+    if (!selectEl.value && filteredTasks.length > 0) {
+        selectEl.value = String(filteredTasks[0]._id);
     }
 
-    if (focusState.taskId && !activeTasks.some((task) => String(task._id) === String(focusState.taskId))) {
+    const hasSelectedTaskInAnyList = focusState.allTasks.some(
+        (task) => task.status === "active" && String(task._id) === String(focusState.taskId)
+    );
+    if (focusState.taskId && !hasSelectedTaskInAnyList) {
         void stopFocusSession("task_no_longer_active");
     }
 
@@ -227,13 +292,15 @@ function updateFocusTaskOptions(tasks) {
 async function loadFocusTasks() {
     const response = await fetch("/tasks", { credentials: "include" });
     if (!response.ok) {
+        focusState.allTasks = [];
         updateFocusTaskOptions([]);
         return [];
     }
 
     const tasks = await response.json();
-    updateFocusTaskOptions(tasks);
-    return tasks;
+    focusState.allTasks = Array.isArray(tasks) ? tasks : [];
+    updateFocusTaskOptions(focusState.allTasks);
+    return focusState.allTasks;
 }
 
 function getFocusLogBody() {
@@ -408,6 +475,8 @@ async function initFocusMode() {
     const stopBtn = document.getElementById("focusStopBtn");
     const statusEl = document.getElementById("focus-status");
     if (!selectEl || !startBtn || !stopBtn || !statusEl) return;
+
+    bindFocusFilterTabs();
 
     try {
         await loadFocusTasks();

--- a/server.js
+++ b/server.js
@@ -10,7 +10,6 @@ const bcrypt = require("bcryptjs"); // Used to hash passwords
 const User = require("./config/models/user"); // User model for the database
 const Task = require("./config/models/task"); // Task model for the database
 const FocusSession = require("./config/models/focusSession"); // FocusSession model for tracking focus sessions
-const rateLimit = require("express-rate-limit");
 const rateLimit = require("express-rate-limit"); // Rate limiting middleware
 const MongoStore = require("connect-mongo").default; // Store sessions in MongoDB
 


### PR DESCRIPTION
### Motivation

- Improve the Focus UI by making it easier to pick tasks via explicit filters (Big 3, Task List, Effort) and surface those filters in the task panel.
- Ensure the focus task list can be filtered client-side and the UI disables filter changes while a session is running.

### Description

- Add tab UI and styles for focus task filters: new `.focus-task-tabs` and `.focus-task-tab` rules in `public/css/focus-page.css` and corresponding tab markup in `public/focus-page.html` with three buttons for `big-three`, `task-list`, and `effort` filters.
- Update the focus task area label text and keep the underlying `<select>` hidden while using a listbox view (`#focusTaskList`) for task selection in `public/focus-page.html`.
- Implement client-side filtering and tab behavior in `public/js/main.js`: add `focusState.filter` and `focusState.allTasks`, implement `getFocusTasksByFilter`, `updateFocusFilterTabs`, and `bindFocusFilterTabs`, wire tabs into `initFocusMode`, and update `updateFocusTaskOptions`/`loadFocusTasks` to use the filtered task set and maintain `focusState.allTasks`.
- Update control logic to disable filter tabs when a focus session is running and to stop sessions when the selected task is no longer active.
- Remove a duplicate require for `express-rate-limit` in `server.js`.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d2d39fc883268975210305b9f33c)