### PR TITLE
Add 'Complete Task' control to focus session and remove per-item complete checkboxes

### DIFF
--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -160,14 +160,11 @@
 }
 
 .focus-task-list-item.big-three-item {
-  grid-template-columns: 1.35rem 1fr;
-  gap: 0.45rem;
+  grid-template-columns: 1fr;
+  gap: 0.35rem;
   align-items: start;
 }
 
-.focus-task-check {
-  margin-top: 0.18rem;
-}
 
 .focus-task-option {
   display: block;

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -103,6 +103,9 @@
               <button id="focusStopBtn" class="paper-button" type="button" hidden disabled>
                 Stop
               </button>
+              <button id="focusCompleteBtn" class="paper-button" type="button" hidden disabled>
+                Complete Task
+              </button>
             </div>
           </article>
         </div>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -124,6 +124,7 @@ function updateFocusModeControls({ running, hasTask } = {}) {
     const taskListEl = document.getElementById("focusTaskList");
     const startBtn = document.getElementById("focusStartBtn");
     const stopBtn = document.getElementById("focusStopBtn");
+    const completeBtn = document.getElementById("focusCompleteBtn");
     const canStart = typeof hasTask === "boolean"
         ? hasTask
         : Boolean(selectEl?.value);
@@ -145,6 +146,10 @@ function updateFocusModeControls({ running, hasTask } = {}) {
     if (stopBtn) {
         stopBtn.hidden = !Boolean(running);
         stopBtn.disabled = !Boolean(running);
+    }
+    if (completeBtn) {
+        completeBtn.hidden = !Boolean(running);
+        completeBtn.disabled = !Boolean(running);
     }
 }
 
@@ -201,59 +206,6 @@ function updateFocusTaskOptions(tasks) {
             item.setAttribute("role", "option");
             item.setAttribute("aria-selected", "false");
 
-            const completeInput = document.createElement("input");
-            completeInput.type = "checkbox";
-            completeInput.className = "task-check big-three-check focus-task-check";
-            completeInput.checked = false;
-            completeInput.setAttribute("aria-label", `Mark task complete: ${task.description || "Untitled task"}`);
-            completeInput.addEventListener("click", (event) => {
-                event.stopPropagation();
-            });
-            completeInput.addEventListener("change", async () => {
-                if (!completeInput.checked) return;
-
-                completeInput.disabled = true;
-                optionButton.disabled = true;
-
-                const payload = { status: "completed" };
-                if (Boolean(task.isBigThree)) {
-                    payload.isBigThree = false;
-                }
-
-                try {
-                    const updateResponse = await fetch(`/tasks/${taskId}`, {
-                        method: "PUT",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify(payload)
-                    });
-
-                    const updateData = await parseApiResponse(updateResponse);
-                    if (!updateResponse.ok) {
-                        completeInput.checked = false;
-                        Toast.show({
-                            message: updateData?.error || "Could not complete task.",
-                            type: "error",
-                            duration: 3000
-                        });
-                        return;
-                    }
-
-                    if (focusState.taskId && String(focusState.taskId) === taskId) {
-                        await stopFocusSession("completed_task");
-                    }
-
-                    await loadFocusTasks();
-                } catch (error) {
-                    console.error("Completing focus-list task failed:", error);
-                    completeInput.checked = false;
-                    Toast.show({ message: "Could not complete task.", type: "error", duration: 3000 });
-                } finally {
-                    if (!focusState.taskId) {
-                        updateFocusModeControls({ running: false, hasTask: Boolean(selectEl.value) });
-                    }
-                }
-            });
-
             const optionButton = document.createElement("button");
             optionButton.type = "button";
             optionButton.className = "focus-task-option";
@@ -265,7 +217,7 @@ function updateFocusTaskOptions(tasks) {
                 updateFocusModeControls({ running: false, hasTask: true });
             });
 
-            item.append(completeInput, optionButton);
+            item.append(optionButton);
             taskListEl.appendChild(item);
         }
     });
@@ -469,12 +421,41 @@ async function stopFocusSession(reason = "manual_stop") {
     }
 }
 
+
+async function completeTask(taskId) {
+    if (!taskId) return { ok: false, error: "Select a task first." };
+
+    const task = focusState.allTasks.find((entry) => String(entry?._id) === String(taskId));
+    const payload = { status: "completed" };
+    if (Boolean(task?.isBigThree)) {
+        payload.isBigThree = false;
+    }
+
+    try {
+        const updateResponse = await fetch(`/tasks/${taskId}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload)
+        });
+        const updateData = await parseApiResponse(updateResponse);
+        if (!updateResponse.ok) {
+            return { ok: false, error: updateData?.error || "Could not complete task." };
+        }
+
+        return { ok: true };
+    } catch (error) {
+        console.error("Completing focus task failed:", error);
+        return { ok: false, error: "Could not complete task." };
+    }
+}
+
 async function initFocusMode() {
     const selectEl = document.getElementById("focusTaskSelect");
     const startBtn = document.getElementById("focusStartBtn");
     const stopBtn = document.getElementById("focusStopBtn");
+    const completeBtn = document.getElementById("focusCompleteBtn");
     const statusEl = document.getElementById("focus-status");
-    if (!selectEl || !startBtn || !stopBtn || !statusEl) return;
+    if (!selectEl || !startBtn || !stopBtn || !completeBtn || !statusEl) return;
 
     bindFocusFilterTabs();
 
@@ -536,6 +517,23 @@ async function initFocusMode() {
 
     stopBtn.addEventListener("click", async () => {
         await stopFocusSession("manual_stop");
+    });
+
+    completeBtn.addEventListener("click", async () => {
+        if (!focusState.taskId) return;
+
+        completeBtn.disabled = true;
+        stopBtn.disabled = true;
+
+        const completion = await completeTask(focusState.taskId);
+        if (!completion.ok) {
+            Toast.show({ message: completion.error, type: "error", duration: 3000 });
+            updateFocusModeControls({ running: Boolean(focusState.taskId), hasTask: Boolean(selectEl.value) });
+            return;
+        }
+
+        await stopFocusSession("completed_task");
+        await loadFocusTasks();
     });
 }
 


### PR DESCRIPTION
### Motivation
- Simplify the focus-mode task selection UI by removing per-task completion checkboxes and centralizing completion into a single control while a focus timer is running.
- Make completing the active task a single, explicit action that also stops the focus session with a `completed_task` reason to keep session logging consistent.

### Description
- Added a new button in the focus session controls: `#focusCompleteBtn` in `public/focus-page.html` to appear alongside the Stop button while a timer is running.
- Removed per-item completion checkboxes from the task list generated by `updateFocusTaskOptions` in `public/js/main.js` and simplified list rows to a single selectable option button.
- Implemented `completeTask(taskId)` in `public/js/main.js` which calls `PUT /tasks/:id` to set `status: "completed"` (and clears `isBigThree` when present) and returns a success/error result.
- Wired the `Complete Task` button in `initFocusMode` to disable controls, call `completeTask`, then call `stopFocusSession("completed_task")` and refresh tasks via `loadFocusTasks()` on success.
- Updated `updateFocusModeControls` to manage visibility/disabled state for the new `completeBtn` and adjusted layout CSS in `public/css/focus-page.css` (`.focus-task-list-item.big-three-item` grid and removed `.focus-task-check` rule) to reflect the removed checkbox.

### Testing
- Ran `node --check public/js/main.js` to validate the modified client script syntax and it succeeded.
- Attempted to run the app with `npm start` to validate end-to-end UI behavior, but startup failed in this environment due to a missing runtime dependency (`Cannot find module 'express-rate-limit'`), so full runtime verification could not be completed.
- Verified DOM wiring by inspecting the updated `initFocusMode` and `updateFocusModeControls` logic and ensured the `completeBtn` flow stops the session with reason `completed_task` and refreshes the task list.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e85a1da483268d1ebad416f2c444)