### PR TITLE
Add task filtering tabs, focus-complete action, and hand-drawn dividers

### DIFF
--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -147,6 +147,11 @@
   opacity: 0.7;
   cursor: not-allowed;
 }
+.focus-task-divider {
+  margin-top: 0.38rem;
+  margin-bottom: 0.22rem;
+}
+
 .focus-task-list {
   margin-top: 0.3rem;
   max-height: 240px;
@@ -160,14 +165,11 @@
 }
 
 .focus-task-list-item.big-three-item {
-  grid-template-columns: 1.35rem 1fr;
-  gap: 0.45rem;
+  grid-template-columns: 1fr;
+  gap: 0.35rem;
   align-items: start;
 }
 
-.focus-task-check {
-  margin-top: 0.18rem;
-}
 
 .focus-task-option {
   display: block;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -832,6 +832,55 @@ input:focus{
   border-radius: 1px;
 }
 
+
+.handdrawn-divider {
+  height: 3px;
+  width: 100%;
+  margin: 0.35rem 0 0.45rem;
+  border-radius: 999px;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      rgba(93, 64, 55, 0.52) 0,
+      rgba(93, 64, 55, 0.52) 8px,
+      rgba(93, 64, 55, 0.2) 8px,
+      rgba(93, 64, 55, 0.2) 12px
+    );
+  transform: rotate(-0.35deg);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.22);
+}
+
+.task-list-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem;
+  margin-top: 0.1rem;
+}
+
+.task-list-tab {
+  border: 1px solid rgba(93, 64, 55, 0.35);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.42);
+  color: #5d4037;
+  font: inherit;
+  font-size: 0.8rem;
+  line-height: 1.2;
+  padding: 0.3rem 0.25rem;
+  cursor: pointer;
+}
+
+.task-list-tab.is-active {
+  border-color: rgba(198, 83, 78, 0.7);
+  background: rgba(247, 204, 220, 0.55);
+  color: #8b3a2e;
+  font-weight: 700;
+}
+
+.task-list-divider {
+  margin-top: 0.35rem;
+  margin-bottom: 0.4rem;
+}
+
 .task-list{
   list-style: none;
   padding: 0;

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -103,7 +103,14 @@
                 </button>
               </div>
 
-              <ul class="task-list scrollable"></ul>
+              <div class="task-list-tabs" role="tablist" aria-label="Filter task list">
+                <button id="dashboardTabTaskList" class="task-list-tab is-active" type="button" role="tab" aria-selected="true" aria-controls="dashboardTaskList" data-filter="task-list">Task List</button>
+                <button id="dashboardTabEffort" class="task-list-tab" type="button" role="tab" aria-selected="false" aria-controls="dashboardTaskList" data-filter="effort">Effort</button>
+                <button id="dashboardTabDueDate" class="task-list-tab" type="button" role="tab" aria-selected="false" aria-controls="dashboardTaskList" data-filter="due-date">Due Date</button>
+              </div>
+              <div class="handdrawn-divider task-list-divider" aria-hidden="true"></div>
+
+              <ul id="dashboardTaskList" class="task-list scrollable"></ul>
               <template id="task-template">
                 <li class="task-item">
                   <label

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -124,6 +124,7 @@
                 aria-label="Select a task to focus on"
                 hidden
               ></select>
+              <div class="handdrawn-divider focus-task-divider" aria-hidden="true"></div>
               <ul
                 id="focusTaskList"
                 class="big-three-list focus-task-list"

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -103,6 +103,9 @@
               <button id="focusStopBtn" class="paper-button" type="button" hidden disabled>
                 Stop
               </button>
+              <button id="focusCompleteBtn" class="paper-button" type="button" hidden disabled>
+                Complete Task
+              </button>
             </div>
           </article>
         </div>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -25,6 +25,12 @@ const focusState = {
     allTasks: []
 };
 
+const dashboardTaskState = {
+    filter: "task-list",
+    allTasks: []
+};
+
+
 function formatFocusDuration(totalSeconds) {
     const safeSeconds = Math.max(0, parseInt(totalSeconds, 10) || 0);
     const minutes = Math.floor(safeSeconds / 60);
@@ -124,6 +130,7 @@ function updateFocusModeControls({ running, hasTask } = {}) {
     const taskListEl = document.getElementById("focusTaskList");
     const startBtn = document.getElementById("focusStartBtn");
     const stopBtn = document.getElementById("focusStopBtn");
+    const completeBtn = document.getElementById("focusCompleteBtn");
     const canStart = typeof hasTask === "boolean"
         ? hasTask
         : Boolean(selectEl?.value);
@@ -145,6 +152,10 @@ function updateFocusModeControls({ running, hasTask } = {}) {
     if (stopBtn) {
         stopBtn.hidden = !Boolean(running);
         stopBtn.disabled = !Boolean(running);
+    }
+    if (completeBtn) {
+        completeBtn.hidden = !Boolean(running);
+        completeBtn.disabled = !Boolean(running);
     }
 }
 
@@ -187,6 +198,11 @@ function updateFocusTaskOptions(tasks) {
         return;
     }
 
+    const placeholderOption = document.createElement("option");
+    placeholderOption.value = "";
+    placeholderOption.textContent = "Select a task";
+    selectEl.appendChild(placeholderOption);
+
     filteredTasks.forEach((task) => {
         const option = document.createElement("option");
         const taskId = String(task._id);
@@ -201,59 +217,6 @@ function updateFocusTaskOptions(tasks) {
             item.setAttribute("role", "option");
             item.setAttribute("aria-selected", "false");
 
-            const completeInput = document.createElement("input");
-            completeInput.type = "checkbox";
-            completeInput.className = "task-check big-three-check focus-task-check";
-            completeInput.checked = false;
-            completeInput.setAttribute("aria-label", `Mark task complete: ${task.description || "Untitled task"}`);
-            completeInput.addEventListener("click", (event) => {
-                event.stopPropagation();
-            });
-            completeInput.addEventListener("change", async () => {
-                if (!completeInput.checked) return;
-
-                completeInput.disabled = true;
-                optionButton.disabled = true;
-
-                const payload = { status: "completed" };
-                if (Boolean(task.isBigThree)) {
-                    payload.isBigThree = false;
-                }
-
-                try {
-                    const updateResponse = await fetch(`/tasks/${taskId}`, {
-                        method: "PUT",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify(payload)
-                    });
-
-                    const updateData = await parseApiResponse(updateResponse);
-                    if (!updateResponse.ok) {
-                        completeInput.checked = false;
-                        Toast.show({
-                            message: updateData?.error || "Could not complete task.",
-                            type: "error",
-                            duration: 3000
-                        });
-                        return;
-                    }
-
-                    if (focusState.taskId && String(focusState.taskId) === taskId) {
-                        await stopFocusSession("completed_task");
-                    }
-
-                    await loadFocusTasks();
-                } catch (error) {
-                    console.error("Completing focus-list task failed:", error);
-                    completeInput.checked = false;
-                    Toast.show({ message: "Could not complete task.", type: "error", duration: 3000 });
-                } finally {
-                    if (!focusState.taskId) {
-                        updateFocusModeControls({ running: false, hasTask: Boolean(selectEl.value) });
-                    }
-                }
-            });
-
             const optionButton = document.createElement("button");
             optionButton.type = "button";
             optionButton.className = "focus-task-option";
@@ -265,17 +228,18 @@ function updateFocusTaskOptions(tasks) {
                 updateFocusModeControls({ running: false, hasTask: true });
             });
 
-            item.append(completeInput, optionButton);
+            item.append(optionButton);
             taskListEl.appendChild(item);
         }
     });
 
-    if (previousValue && filteredTasks.some((task) => String(task._id) === previousValue)) {
+    const runningTaskId = String(focusState.taskId || "");
+    if (runningTaskId && filteredTasks.some((task) => String(task._id) === runningTaskId)) {
+        selectEl.value = runningTaskId;
+    } else if (previousValue && filteredTasks.some((task) => String(task._id) === previousValue)) {
         selectEl.value = previousValue;
-    }
-
-    if (!selectEl.value && filteredTasks.length > 0) {
-        selectEl.value = String(filteredTasks[0]._id);
+    } else {
+        selectEl.value = "";
     }
 
     const hasSelectedTaskInAnyList = focusState.allTasks.some(
@@ -469,12 +433,41 @@ async function stopFocusSession(reason = "manual_stop") {
     }
 }
 
+
+async function completeTask(taskId) {
+    if (!taskId) return { ok: false, error: "Select a task first." };
+
+    const task = focusState.allTasks.find((entry) => String(entry?._id) === String(taskId));
+    const payload = { status: "completed" };
+    if (Boolean(task?.isBigThree)) {
+        payload.isBigThree = false;
+    }
+
+    try {
+        const updateResponse = await fetch(`/tasks/${taskId}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload)
+        });
+        const updateData = await parseApiResponse(updateResponse);
+        if (!updateResponse.ok) {
+            return { ok: false, error: updateData?.error || "Could not complete task." };
+        }
+
+        return { ok: true };
+    } catch (error) {
+        console.error("Completing focus task failed:", error);
+        return { ok: false, error: "Could not complete task." };
+    }
+}
+
 async function initFocusMode() {
     const selectEl = document.getElementById("focusTaskSelect");
     const startBtn = document.getElementById("focusStartBtn");
     const stopBtn = document.getElementById("focusStopBtn");
+    const completeBtn = document.getElementById("focusCompleteBtn");
     const statusEl = document.getElementById("focus-status");
-    if (!selectEl || !startBtn || !stopBtn || !statusEl) return;
+    if (!selectEl || !startBtn || !stopBtn || !completeBtn || !statusEl) return;
 
     bindFocusFilterTabs();
 
@@ -536,6 +529,23 @@ async function initFocusMode() {
 
     stopBtn.addEventListener("click", async () => {
         await stopFocusSession("manual_stop");
+    });
+
+    completeBtn.addEventListener("click", async () => {
+        if (!focusState.taskId) return;
+
+        completeBtn.disabled = true;
+        stopBtn.disabled = true;
+
+        const completion = await completeTask(focusState.taskId);
+        if (!completion.ok) {
+            Toast.show({ message: completion.error, type: "error", duration: 3000 });
+            updateFocusModeControls({ running: Boolean(focusState.taskId), hasTask: Boolean(selectEl.value) });
+            return;
+        }
+
+        await stopFocusSession("completed_task");
+        await loadFocusTasks();
     });
 }
 
@@ -827,6 +837,8 @@ document.addEventListener("DOMContentLoaded", () => {
         clearCompletedButton.addEventListener("click", clearCompletedTasks);
     }
 
+    bindDashboardTaskFilterTabs();
+
     checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
     initFocusMode();
 });
@@ -945,7 +957,8 @@ async function fetchTasks() {
     const tasks = await response.json();
 
     if (response.ok) {
-        updateTaskList(tasks);
+        dashboardTaskState.allTasks = Array.isArray(tasks) ? tasks : [];
+        updateTaskList(dashboardTaskState.allTasks);
     } else {
         console.error("Error fetching tasks:", tasks.error);
         alert("Please log in to see your tasks.");
@@ -1439,14 +1452,17 @@ function openTaskDetailPanel(task, handlers) {
     document.body.classList.add("task-panel-open");
 }
 
-// Function to update the UI with fetched tasks
-function updateTaskList(tasks) {
-    const listOfTasks = document.querySelector(".task-list");
-    const taskTemplate = document.querySelector("#task-template");
-    const bigThreeInteractions = new Map();
-    tasks = Array.isArray(tasks) ? tasks : [];
+function getTaskDueSortTimestamp(dueDate) {
+    if (!dueDate) return Number.POSITIVE_INFINITY;
+    const parsedDate = new Date(dueDate);
+    if (Number.isNaN(parsedDate.getTime())) return Number.POSITIVE_INFINITY;
+    return parsedDate.getTime();
+}
 
-    const sortedTasks = tasks.slice().sort((a, b) => {
+function getDashboardTasksByFilter(tasks, filter = "task-list") {
+    const safeTasks = Array.isArray(tasks) ? tasks.slice() : [];
+
+    return safeTasks.sort((a, b) => {
         const aCompleted = a.status === "completed";
         const bCompleted = b.status === "completed";
 
@@ -1454,10 +1470,60 @@ function updateTaskList(tasks) {
             return aCompleted ? 1 : -1;
         }
 
-        const aCreated = new Date(a.createdAt || 0).getTime();
-        const bCreated = new Date(b.createdAt || 0).getTime();
+        if (filter === "effort") {
+            const effortA = Number(a?.effortLevel) || 5;
+            const effortB = Number(b?.effortLevel) || 5;
+            if (effortA !== effortB) return effortA - effortB;
+        } else if (filter === "due-date") {
+            const dueA = getTaskDueSortTimestamp(a?.dueDate);
+            const dueB = getTaskDueSortTimestamp(b?.dueDate);
+            if (dueA !== dueB) return dueA - dueB;
+        }
+
+        const aCreated = new Date(a?.createdAt || 0).getTime();
+        const bCreated = new Date(b?.createdAt || 0).getTime();
         return bCreated - aCreated;
     });
+}
+
+function updateDashboardTaskFilterTabs(selectedFilter) {
+    const tabButtons = document.querySelectorAll(".task-list-tab");
+    if (!tabButtons.length) return;
+
+    tabButtons.forEach((buttonEl) => {
+        const isActive = buttonEl.dataset.filter === selectedFilter;
+        buttonEl.classList.toggle("is-active", isActive);
+        buttonEl.setAttribute("aria-selected", isActive ? "true" : "false");
+    });
+}
+
+function bindDashboardTaskFilterTabs() {
+    const tabButtons = document.querySelectorAll(".task-list-tab");
+    if (!tabButtons.length) return;
+
+    tabButtons.forEach((buttonEl) => {
+        buttonEl.addEventListener("click", () => {
+            const filter = buttonEl.dataset.filter || "task-list";
+            if (filter === dashboardTaskState.filter) return;
+
+            dashboardTaskState.filter = filter;
+            updateTaskList(dashboardTaskState.allTasks);
+        });
+    });
+
+    updateDashboardTaskFilterTabs(dashboardTaskState.filter);
+}
+
+// Function to update the UI with fetched tasks
+function updateTaskList(tasks) {
+    const listOfTasks = document.querySelector(".task-list");
+    const taskTemplate = document.querySelector("#task-template");
+    const bigThreeInteractions = new Map();
+    tasks = Array.isArray(tasks) ? tasks : [];
+    dashboardTaskState.allTasks = tasks;
+
+    const baseSortedTasks = getDashboardTasksByFilter(tasks, "task-list");
+    const sortedTasks = getDashboardTasksByFilter(tasks, dashboardTaskState.filter);
 
     if (!listOfTasks) {
         return; // Avoid errors on pages without the dashboard
@@ -1663,8 +1729,8 @@ function updateTaskList(tasks) {
         listOfTasks.appendChild(clone);
     });
 
-    updateFocusTaskOptions(sortedTasks);
-    updateBigThreeWidget(sortedTasks, bigThreeInteractions);
+    updateFocusTaskOptions(baseSortedTasks);
+    updateBigThreeWidget(baseSortedTasks, bigThreeInteractions);
 
     // Update the task counter
     document.querySelectorAll(".item-counter").forEach((el) => {
@@ -1675,6 +1741,8 @@ function updateTaskList(tasks) {
     el.textContent = String(activeCount);
     });
 
+    updateDashboardTaskFilterTabs(dashboardTaskState.filter);
+
     const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
     if (clearCompletedButton) {
         const hasCompletedTasks = Array.isArray(tasks) && tasks.some((task) => task.status === "completed");
@@ -1682,7 +1750,7 @@ function updateTaskList(tasks) {
     }
 
     // If no tasks, show a friendly message
-    if (tasks.length === 0) {
+    if (sortedTasks.length === 0) {
         listOfTasks.innerHTML = "<p>No tasks found. Add a new task to get started!</p>";
     }
 }


### PR DESCRIPTION
### Motivation

- Provide quick filtering on the dashboard task list (Task List / Effort / Due Date) to let users sort and view tasks by common criteria.  
- Improve focus-mode workflow by allowing the running focus session's task to be marked completed without leaving the session.  
- Enhance visual styling with hand-drawn dividers and consistent tab UI for both dashboard and focus panels.

### Description

- Added tabbed filters and a decorative divider to the dashboard: new HTML tab buttons and a `handdrawn-divider` element, plus CSS classes `.task-list-tabs`, `.task-list-tab`, and `.task-list-divider`.  
- Implemented dashboard filtering state and behavior with a new `dashboardTaskState`, `getDashboardTasksByFilter`, `bindDashboardTaskFilterTabs`, and `updateDashboardTaskFilterTabs`, and wired filter changes into `updateTaskList`.  
- Updated `updateTaskList` to sort tasks by completion, created date, and to support `effort` and `due-date` filters, and to use a base sorted list when populating focus-related widgets.  
- Enhanced focus UI: removed inline per-item completion checkboxes from the focus task list, added a `Complete Task` button to the focus controls, and implemented `completeTask` plus wiring in `initFocusMode` and `updateFocusModeControls` to support completing the running task.  
- Minor UI/UX tweaks: added a placeholder option in the focus select (`Select a task`), improved selection sync logic for running tasks, and added `.focus-task-divider` CSS for consistent spacing.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e85a1da483268d1ebad416f2c444)