### PR TITLE
Focus mode UX improvements, placeholder pages, and CSS/JS refactor

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>Stick A Pin</title>
@@ -7,7 +7,11 @@
     <script src="js/notification.js" defer></script>
     <script src="js/main.js" defer></script>
     <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/assets/image/donezo-logo.png"
+    />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
@@ -20,7 +24,7 @@
       href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-        <link
+    <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
     />
@@ -42,7 +46,7 @@
         <div class="logo-container">
           <div class="logo-sticky">
             <div class="thumbtack">
-              <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+              <i class="fa-solid fa-thumbtack" style="color: #c6534e"></i>
             </div>
           </div>
           <span class="brand-name">Stick A Pin</span>
@@ -51,7 +55,9 @@
 
       <ul class="nav-links" id="nav-drawer">
         <li><a href="/dashboard.html" class="nav-item">Board</a></li>
-        <li><a href="/calendar-page.html" class="nav-item active">Calendar</a></li>
+        <li>
+          <a href="/calendar-page.html" class="nav-item active">Calendar</a>
+        </li>
         <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
         <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
         <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
@@ -70,23 +76,46 @@
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>
 
-    <main class="corkboard" style="max-width: 1100px; margin: 2rem auto;">
-      <section class="sticky-note blue thumbtack" style="padding: 1.25rem;">
-        <h1 class="widget-title">
-          <i class="fa-solid fa-calendar-days" style="color: #c6534e;"></i>
+    <main
+      class="corkboard placeholder-board"
+      style="max-width: 1100px; margin: 0 auto"
+    >
+      <section
+        class="sticky-note orange caution-tape page-placeholder"
+        aria-label="Calendar page coming soon"
+      >
+        <h2 class="widget-title">
+          <i class="fa-solid fa-calendar-days" style="color: #c6534e"></i>
           Calendar
-        </h1>
-        <p>Calendar view is coming soon. Use the board to manage your tasks today.</p>
+        </h2>
+        <p>
+          This page is currently in progress. Check back soon for your full
+          calendar view.
+        </p>
       </section>
     </main>
 
-    <div id="toast" class="toast toast--default" role="status" aria-live="polite" aria-atomic="true" hidden>
+    <div
+      id="toast"
+      class="toast toast--default"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      hidden
+    >
       <div class="toast__icon" aria-hidden="true">i</div>
       <div class="toast__content">
         <div id="toastTitle" class="toast__title" hidden></div>
         <div id="toastMessage" class="toast__message"></div>
       </div>
-      <button id="toastClose" class="toast__close" type="button" aria-label="Close notification">×</button>
+      <button
+        id="toastClose"
+        class="toast__close"
+        type="button"
+        aria-label="Close notification"
+      >
+        ×
+      </button>
       <div class="toast__progress"></div>
     </div>
   </body>

--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -115,8 +115,6 @@
   display: none !important;
 }
 
-
-
 .focus-task-tabs {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -169,7 +167,6 @@
   gap: 0.35rem;
   align-items: start;
 }
-
 
 .focus-task-option {
   display: block;
@@ -269,6 +266,26 @@
   text-align: center;
   font-size: 1.05rem;
   color: #5d4037;
+  min-height: 1.35em;
+}
+
+.focus-quote-text.is-typing::after {
+  content: "|";
+  margin-left: 0.1rem;
+  opacity: 0.75;
+  animation: focus-caret-blink 0.75s steps(1, end) infinite;
+}
+
+@keyframes focus-caret-blink {
+  0%,
+  49% {
+    opacity: 0.75;
+  }
+
+  50%,
+  100% {
+    opacity: 0.2;
+  }
 }
 
 @media (max-width: 768px), (hover: none) and (pointer: coarse) {

--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -269,25 +269,6 @@
   min-height: 1.35em;
 }
 
-.focus-quote-text.is-typing::after {
-  content: "|";
-  margin-left: 0.1rem;
-  opacity: 0.75;
-  animation: focus-caret-blink 0.75s steps(1, end) infinite;
-}
-
-@keyframes focus-caret-blink {
-  0%,
-  49% {
-    opacity: 0.75;
-  }
-
-  50%,
-  100% {
-    opacity: 0.2;
-  }
-}
-
 @media (max-width: 768px), (hover: none) and (pointer: coarse) {
   #focus-mode-widget.focus-board {
     grid-template-columns: 1fr;

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -16,45 +16,54 @@
    Creates a corkboard texture using layered gradients
    ============================================================ */
 .corkboard {
-    height: 70vh;
-    width: 80vw;
-    justify-self: center;
-    padding: 2%;
+  height: 70vh;
+  width: 80vw;
+  justify-self: center;
+  padding: 2%;
 
-    /* Base cork color */
-    background-color: #cfa36a;
+  /* Base cork color */
+  background-color: #cfa36a;
 
-    /* Cork texture layers */
-    background-image:
-        radial-gradient(circle at 15% 25%, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0) 40%),
-        radial-gradient(circle at 75% 65%, rgba(0,0,0,0.06) 0%, rgba(0,0,0,0) 45%),
-        repeating-linear-gradient(
-        45deg,
-        rgba(255,255,255,0.04),
-        rgba(255,255,255,0.04) 2px,
-        rgba(0,0,0,0.04) 4px,
-        rgba(0,0,0,0.04) 6px
-        );
+  /* Cork texture layers */
+  background-image:
+    radial-gradient(
+      circle at 15% 25%,
+      rgba(255, 255, 255, 0.08) 0%,
+      rgba(255, 255, 255, 0) 40%
+    ),
+    radial-gradient(
+      circle at 75% 65%,
+      rgba(0, 0, 0, 0.06) 0%,
+      rgba(0, 0, 0, 0) 45%
+    ),
+    repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.04),
+      rgba(255, 255, 255, 0.04) 2px,
+      rgba(0, 0, 0, 0.04) 4px,
+      rgba(0, 0, 0, 0.04) 6px
+    );
 
-    background-size: cover;
-    background-blend-mode: multiply;
+  background-size: cover;
+  background-blend-mode: multiply;
 
-    /* Frame */
-    border: 6px solid #000;
-    border-radius: 6px;
+  /* Frame */
+  border: 6px solid #000;
+  border-radius: 6px;
 }
 
+.corkboard.placeholder-board {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 
 .three-columns {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   column-gap: 5%;
   height: 80%;
-
 }
-
-
-
 
 /* ============================================================
    STICKY NOTE BASE
@@ -62,7 +71,6 @@
    ============================================================ */
 .sticky-note {
   position: relative;
-  
 
   /* Color controlled via CSS variable for easy theming */
   background: var(--note-color, #fff3a4);
@@ -75,8 +83,8 @@
 
   /* Depth + paper feel */
   box-shadow:
-    0 4px 8px rgba(0,0,0,0.25),
-    inset 0 -12px 16px rgba(0,0,0,0.08);
+    0 4px 8px rgba(0, 0, 0, 0.25),
+    inset 0 -12px 16px rgba(0, 0, 0, 0.08);
 
   /* Slight imperfection */
   transform: rotate(-1.5deg);
@@ -88,11 +96,11 @@
    Modifier classes that change note color
    ============================================================ */
 .sticky-note.yellow {
-  --note-color: #FFF9E1;
+  --note-color: #fff9e1;
 }
 
 .sticky-note.blue {
-  --note-color: #E3F2FD;
+  --note-color: #e3f2fd;
 }
 
 .sticky-note.green {
@@ -100,11 +108,22 @@
 }
 
 .sticky-note.pink {
-  --note-color: #FCE4EC;
+  --note-color: #fce4ec;
 }
 
 .sticky-note.orange {
-  --note-color: #ffd9b3;
+  --note-color: #ffc06b;
+}
+
+.sticky-note.page-placeholder {
+  width: min(480px, 90%);
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.sticky-note.page-placeholder p {
+  width: auto;
+  margin-top: 0.75rem;
 }
 
 .sticky-note.purple {
@@ -134,7 +153,7 @@
   background: radial-gradient(circle at 30% 30%, #ff6b6b, #a40000);
   border-radius: 50%;
 
-  box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 
 /* Tack needle */
@@ -149,7 +168,7 @@
   height: 12px;
 
   background: #555;
-  box-shadow: 0 2px 2px rgba(0,0,0,0.3);
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
 }
 
 /* Thumbtack comes off when note is hovered */
@@ -168,9 +187,10 @@
 /* Smooth animation */
 .sticky-note.thumbtack::before,
 .sticky-note.thumbtack::after {
-  transition: transform 220ms ease, opacity 220ms ease;
+  transition:
+    transform 220ms ease,
+    opacity 220ms ease;
 }
-
 
 /* ============================================================
    RANDOM ROTATION
@@ -202,7 +222,6 @@
   z-index: 10;
 }
 
-
 /* ============================================================
    HOVER INTERACTION
    Raises note to feel touchable
@@ -212,13 +231,9 @@
   transform: translateY(-4px) scale(1.02);
 
   box-shadow:
-    0 10px 20px rgba(0,0,0,0.3),
-    inset 0 -12px 16px rgba(0,0,0,0.08);
+    0 10px 20px rgba(0, 0, 0, 0.3),
+    inset 0 -12px 16px rgba(0, 0, 0, 0.08);
 }
-
-
-
-
 
 /* ============================================================
    SINGLE TAPE MODIFIER
@@ -239,15 +254,15 @@
   background:
     repeating-linear-gradient(
       45deg,
-      rgba(255,255,255,0.15),
-      rgba(255,255,255,0.15) 2px,
-      rgba(0,0,0,0.05) 4px
+      rgba(255, 255, 255, 0.15),
+      rgba(255, 255, 255, 0.15) 2px,
+      rgba(0, 0, 0, 0.05) 4px
     ),
     #e6d6a8;
 
   border-radius: 3px;
 
-  box-shadow: 0 2px 4px rgba(0,0,0,0.25);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
   z-index: 2;
 }
 
@@ -262,7 +277,7 @@
   width: 64px;
   height: 18px;
 
-  background: rgba(255,255,255,0.25);
+  background: rgba(255, 255, 255, 0.25);
   mix-blend-mode: overlay;
 
   pointer-events: none;
@@ -280,10 +295,66 @@
 /* Smooth animation */
 .sticky-note.tape::before,
 .sticky-note.tape::after {
-  transition: transform 220ms ease, opacity 220ms ease;
+  transition:
+    transform 220ms ease,
+    opacity 220ms ease;
 }
 
+/* ============================================================
+   CAUTION TAPE MODIFIER
+   Centered black/yellow "police tape" strip
+   ============================================================ */
+.sticky-note.caution-tape::before {
+  content: "";
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%) rotate(-3deg);
+  width: 120px;
+  height: 22px;
+  border-radius: 3px;
+  background: repeating-linear-gradient(
+    -45deg,
+    #1f1f1f 0,
+    #1f1f1f 12px,
+    #f6ca26 12px,
+    #f6ca26 24px
+  );
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  z-index: 2;
+}
 
+.sticky-note.caution-tape::after {
+  content: "";
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%) rotate(-3deg);
+  width: 120px;
+  height: 22px;
+  border-radius: 3px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.28),
+    rgba(255, 255, 255, 0)
+  );
+  pointer-events: none;
+}
+
+.sticky-note.caution-tape:hover::before,
+.sticky-note.caution-tape:hover::after,
+.sticky-note.caution-tape.in-view-hover::before,
+.sticky-note.caution-tape.in-view-hover::after {
+  transform: translateX(-50%) translateY(-18px) rotate(8deg);
+  opacity: 0;
+}
+
+.sticky-note.caution-tape::before,
+.sticky-note.caution-tape::after {
+  transition:
+    transform 220ms ease,
+    opacity 220ms ease;
+}
 
 /* ============================================================
    DOUBLE TAPE MODIFIER
@@ -303,15 +374,15 @@
   background:
     repeating-linear-gradient(
       45deg,
-      rgba(255,255,255,0.18),
-      rgba(255,255,255,0.18) 2px,
-      rgba(0,0,0,0.06) 4px
+      rgba(255, 255, 255, 0.18),
+      rgba(255, 255, 255, 0.18) 2px,
+      rgba(0, 0, 0, 0.06) 4px
     ),
     #e6d6a8;
 
   border-radius: 3px;
 
-  box-shadow: 0 2px 4px rgba(0,0,0,0.25);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
   z-index: 2;
 }
 
@@ -343,9 +414,10 @@
 /* Smooth animation */
 .sticky-note.double-tape::before,
 .sticky-note.double-tape::after {
-  transition: transform 220ms ease, opacity 220ms ease;
+  transition:
+    transform 220ms ease,
+    opacity 220ms ease;
 }
-
 
 /* ============================================================
    ACCOUNT DROPDOWN (HAND-DRAWN LOOK)
@@ -353,68 +425,67 @@
    ============================================================ */
 
 .account-dropdown {
-    position: relative;
-    font-family: "Itim", serif;
+  position: relative;
+  font-family: "Itim", serif;
 }
 
 .account-trigger {
-    background: #f7f3b2;
-    border: none;
-    padding: 10px 14px;
-    border-radius: 16px 14px 18px 13px;
-    box-shadow: 0 6px 12px rgba(0,0,0,0.15);
-    cursor: pointer;
+  background: #f7f3b2;
+  border: none;
+  padding: 10px 14px;
+  border-radius: 16px 14px 18px 13px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  cursor: pointer;
 }
 
 /* Dropdown menu container */
 .account-menu {
-    position: absolute;
-    top: 120%;
-    right: 0;
-    min-width: 180px;
-    background: #f7f3b2;
-    border-radius: 18px 14px 20px 12px;
-    box-shadow: 0 10px 20px rgba(0,0,0,0.2);
-    list-style: none;
-    padding: 6px;
-    margin: 0;
-    display: none;
-    z-index: 100;
+  position: absolute;
+  top: 120%;
+  right: 0;
+  min-width: 180px;
+  background: #f7f3b2;
+  border-radius: 18px 14px 20px 12px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+  list-style: none;
+  padding: 6px;
+  margin: 0;
+  display: none;
+  z-index: 100;
 }
 
 /* Open state: menu visible */
 .account-dropdown.open .account-menu {
-    display: block;
+  display: block;
 }
 
 /* Menu items */
 .account-menu li {
-    padding: 10px;
-    border-radius: 12px 10px 14px 11px;
-    cursor: pointer;
+  padding: 10px;
+  border-radius: 12px 10px 14px 11px;
+  cursor: pointer;
 }
 
 /* Menu item hover state */
 .account-menu li:hover {
-    background: #d86f67;
-    color: white;
+  background: #d86f67;
+  color: white;
 }
 
 /* Menu divider */
 .account-menu .divider {
-    height: 1px;
-    background: rgba(0,0,0,0.15);
-    margin: 6px 0;
-    pointer-events: none;
+  height: 1px;
+  background: rgba(0, 0, 0, 0.15);
+  margin: 6px 0;
+  pointer-events: none;
 }
 
 /* Logout emphasis styling */
 .account-menu .logout {
-    color: #b33a35;
+  color: #b33a35;
 }
 
 .account-menu .logout:hover {
-    background: #b33a35;
-    color: white;
+  background: #b33a35;
+  color: white;
 }
-

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>Stick A Pin</title>
@@ -7,7 +7,11 @@
     <script src="js/notification.js" defer></script>
     <script src="js/main.js" defer></script>
     <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/assets/image/donezo-logo.png"
+    />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
@@ -20,7 +24,7 @@
       href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-        <link
+    <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
     />
@@ -28,14 +32,20 @@
   <body>
     <nav class="navbar">
       <div class="nav-left">
-        <button class="nav__toggle" type="button" aria-label="Open menu" aria-controls="nav-drawer" aria-expanded="false">
+        <button
+          class="nav__toggle"
+          type="button"
+          aria-label="Open menu"
+          aria-controls="nav-drawer"
+          aria-expanded="false"
+        >
           <i class="fa-solid fa-bars" aria-hidden="true"></i>
           <span class="sr-only">Menu</span>
         </button>
         <div class="logo-container">
           <div class="logo-sticky">
             <div class="thumbtack">
-              <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+              <i class="fa-solid fa-thumbtack" style="color: #c6534e"></i>
             </div>
           </div>
           <span class="brand-name">Stick A Pin</span>
@@ -44,7 +54,9 @@
       <ul class="nav-links" id="nav-drawer">
         <li><a href="/dashboard.html" class="nav-item">Board</a></li>
         <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
-        <li><a href="/feedback-page.html" class="nav-item active">Feedback</a></li>
+        <li>
+          <a href="/feedback-page.html" class="nav-item active">Feedback</a>
+        </li>
         <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
         <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
         <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
@@ -61,23 +73,46 @@
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>
 
-    <main class="corkboard" style="max-width: 1100px; margin: 2rem auto;">
-      <section class="sticky-note thumbtack" style="padding: 1.25rem;">
-        <h1 class="widget-title">
-          <i class="fa-solid fa-comment-dots" style="color: #c6534e;"></i>
+    <main
+      class="corkboard placeholder-board"
+      style="max-width: 1100px; margin: 0 auto"
+    >
+      <section
+        class="sticky-note orange caution-tape page-placeholder"
+        aria-label="Feedback page coming soon"
+      >
+        <h2 class="widget-title">
+          <i class="fa-solid fa-comment-dots" style="color: #c6534e"></i>
           Feedback
-        </h1>
-        <p>We value your feedback. Please share ideas and suggestions with the team.</p>
+        </h2>
+        <p>
+          This page is currently in progress. Check back soon for feedback tools
+          and updates.
+        </p>
       </section>
     </main>
 
-    <div id="toast" class="toast toast--default" role="status" aria-live="polite" aria-atomic="true" hidden>
+    <div
+      id="toast"
+      class="toast toast--default"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      hidden
+    >
       <div class="toast__icon" aria-hidden="true">i</div>
       <div class="toast__content">
         <div id="toastTitle" class="toast__title" hidden></div>
         <div id="toastMessage" class="toast__message"></div>
       </div>
-      <button id="toastClose" class="toast__close" type="button" aria-label="Close notification">×</button>
+      <button
+        id="toastClose"
+        class="toast__close"
+        type="button"
+        aria-label="Close notification"
+      >
+        ×
+      </button>
       <div class="toast__progress"></div>
     </div>
   </body>

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -75,7 +75,11 @@
     <div id="nav-backdrop" aria-hidden="true"></div>
 
     <main class="corkboard" style="max-width: 1200px; margin: 0 auto">
-      <section id="focus-mode-widget" class="focus-board" aria-label="Focus mode board">
+      <section
+        id="focus-mode-widget"
+        class="focus-board"
+        aria-label="Focus mode board"
+      >
         <div class="focus-column focus-column-left">
           <article class="sticky-note yellow tape focus-card focus-log-card">
             <h2 class="focus-log-title">Focus Log</h2>
@@ -94,16 +98,30 @@
               Pick a task and start a focus session.
             </p>
             <div class="focus-session-center">
-              <span id="focusTimer" class="focus-timer" aria-live="polite">00:00</span>
+              <span id="focusTimer" class="focus-timer" aria-live="polite"
+                >00:00</span
+              >
             </div>
             <div class="focus-controls">
               <button id="focusStartBtn" class="paper-button" type="button">
                 Start
               </button>
-              <button id="focusStopBtn" class="paper-button" type="button" hidden disabled>
+              <button
+                id="focusStopBtn"
+                class="paper-button"
+                type="button"
+                hidden
+                disabled
+              >
                 Stop
               </button>
-              <button id="focusCompleteBtn" class="paper-button" type="button" hidden disabled>
+              <button
+                id="focusCompleteBtn"
+                class="paper-button"
+                type="button"
+                hidden
+                disabled
+              >
                 Complete Task
               </button>
             </div>
@@ -113,18 +131,57 @@
         <div class="focus-column focus-column-right">
           <article class="sticky-note blue tape focus-card focus-task-card">
             <div class="paper-field">
-              <label id="focusTaskLabel" for="focusTaskSelect">What should we focus on right now?</label>
-              <div class="focus-task-tabs" role="tablist" aria-label="Filter focus tasks">
-                <button id="focusTabBigThree" class="focus-task-tab is-active" type="button" role="tab" aria-selected="true" aria-controls="focusTaskList" data-filter="big-three">Big 3</button>
-                <button id="focusTabTaskList" class="focus-task-tab" type="button" role="tab" aria-selected="false" aria-controls="focusTaskList" data-filter="task-list">Task List</button>
-                <button id="focusTabEffort" class="focus-task-tab" type="button" role="tab" aria-selected="false" aria-controls="focusTaskList" data-filter="effort">Effort</button>
+              <label id="focusTaskLabel" for="focusTaskSelect"
+                >What should we focus on right now?</label
+              >
+              <div
+                class="focus-task-tabs"
+                role="tablist"
+                aria-label="Filter focus tasks"
+              >
+                <button
+                  id="focusTabBigThree"
+                  class="focus-task-tab is-active"
+                  type="button"
+                  role="tab"
+                  aria-selected="true"
+                  aria-controls="focusTaskList"
+                  data-filter="big-three"
+                >
+                  Big 3
+                </button>
+                <button
+                  id="focusTabTaskList"
+                  class="focus-task-tab"
+                  type="button"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="focusTaskList"
+                  data-filter="task-list"
+                >
+                  Task List
+                </button>
+                <button
+                  id="focusTabEffort"
+                  class="focus-task-tab"
+                  type="button"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="focusTaskList"
+                  data-filter="effort"
+                >
+                  Effort
+                </button>
               </div>
               <select
                 id="focusTaskSelect"
                 aria-label="Select a task to focus on"
                 hidden
               ></select>
-              <div class="handdrawn-divider focus-task-divider" aria-hidden="true"></div>
+              <div
+                class="handdrawn-divider focus-task-divider"
+                aria-hidden="true"
+              ></div>
               <ul
                 id="focusTaskList"
                 class="big-three-list focus-task-list"
@@ -135,7 +192,11 @@
           </article>
 
           <article class="sticky-note pink tape focus-card focus-quote-card">
-            <p class="focus-quote-text">Put a encouraging quote here</p>
+            <p
+              id="focusQuoteText"
+              class="focus-quote-text"
+              aria-live="polite"
+            ></p>
           </article>
         </div>
       </section>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,1758 +1,2183 @@
 // Auth and tasks behavior for Donezo
 
 async function parseApiResponse(response) {
-    const contentType = response.headers.get("content-type") || "";
+  const contentType = response.headers.get("content-type") || "";
 
-    if (contentType.includes("application/json")) {
-        try {
-            return await response.json();
-        } catch (error) {
-            const fallbackText = await response.text().catch(() => "");
-            return { error: fallbackText || "Unexpected server response" };
-        }
+  if (contentType.includes("application/json")) {
+    try {
+      return await response.json();
+    } catch (error) {
+      const fallbackText = await response.text().catch(() => "");
+      return { error: fallbackText || "Unexpected server response" };
     }
+  }
 
-    const text = await response.text();
-    return { error: text || "Unexpected server response" };
+  const text = await response.text();
+  return { error: text || "Unexpected server response" };
 }
 
 const focusState = {
-    taskId: null,
-    sessionId: null,
-    startedAt: null,
-    timerIntervalId: null,
-    filter: "big-three",
-    allTasks: []
+  taskId: null,
+  sessionId: null,
+  startedAt: null,
+  timerIntervalId: null,
+  quoteTimeoutIds: [],
+  quoteTypingIntervalId: null,
+  currentQuoteToken: 0,
+  lastQuote: {
+    general: null,
+    persistence: null,
+    completion: null,
+    timed: null,
+  },
+  filter: "big-three",
+  allTasks: [],
+};
+
+const focusQuotes = {
+  general: [
+    "You showed up. That’s the hardest part.",
+    "Just this task for now.",
+    "Small progress still counts.",
+    "Stay with this moment.",
+    "One step is enough.",
+    "No rush. Just focus.",
+    "Your effort is doing the work.",
+    "Momentum builds quietly.",
+    "You’re moving forward.",
+    "Keep going — this moment counts.",
+    "Consistency beats intensity.",
+    "It doesn’t have to be perfect.",
+    "Progress, not perfection.",
+    "Just explore the next step.",
+    "You only need to begin.",
+    "Even five minutes matters.",
+  ],
+  persistence: [
+    "Still here. Still working.",
+    "Stay curious about the next step.",
+    "Keep the thread going.",
+    "You’re building momentum.",
+  ],
+  completion: [
+    "Nice work staying with it.",
+    "That effort mattered.",
+    "You gave it your attention.",
+    "One focused session down.",
+  ],
+  timed: {
+    twoMinutes: "Starting was the hardest part.",
+    fiveMinutes: "You’re finding your rhythm.",
+    tenMinutes: "Momentum is building.",
+  },
 };
 
 const dashboardTaskState = {
-    filter: "task-list",
-    allTasks: []
+  filter: "task-list",
+  allTasks: [],
 };
 
-
 function formatFocusDuration(totalSeconds) {
-    const safeSeconds = Math.max(0, parseInt(totalSeconds, 10) || 0);
-    const minutes = Math.floor(safeSeconds / 60);
-    const seconds = safeSeconds % 60;
-    return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  const safeSeconds = Math.max(0, parseInt(totalSeconds, 10) || 0);
+  const minutes = Math.floor(safeSeconds / 60);
+  const seconds = safeSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
 function renderFocusTimer() {
-    const timerEl = document.getElementById("focusTimer");
-    if (!timerEl) return;
+  const timerEl = document.getElementById("focusTimer");
+  if (!timerEl) return;
 
-    if (!focusState.startedAt) {
-        timerEl.textContent = "00:00";
-        return;
-    }
+  if (!focusState.startedAt) {
+    timerEl.textContent = "00:00";
+    return;
+  }
 
-    const elapsedSeconds = Math.floor((Date.now() - focusState.startedAt) / 1000);
-    timerEl.textContent = formatFocusDuration(elapsedSeconds);
+  const elapsedSeconds = Math.floor((Date.now() - focusState.startedAt) / 1000);
+  timerEl.textContent = formatFocusDuration(elapsedSeconds);
 }
 
 function startFocusTimer() {
-    if (focusState.timerIntervalId) {
-        window.clearInterval(focusState.timerIntervalId);
-    }
-    renderFocusTimer();
-    focusState.timerIntervalId = window.setInterval(renderFocusTimer, 1000);
+  if (focusState.timerIntervalId) {
+    window.clearInterval(focusState.timerIntervalId);
+  }
+  renderFocusTimer();
+  focusState.timerIntervalId = window.setInterval(renderFocusTimer, 1000);
 }
 
 function stopFocusTimer() {
-    if (focusState.timerIntervalId) {
-        window.clearInterval(focusState.timerIntervalId);
-        focusState.timerIntervalId = null;
+  if (focusState.timerIntervalId) {
+    window.clearInterval(focusState.timerIntervalId);
+    focusState.timerIntervalId = null;
+  }
+}
+
+function getFocusQuoteEl() {
+  return document.getElementById("focusQuoteText");
+}
+
+function clearFocusQuoteTimers() {
+  focusState.quoteTimeoutIds.forEach((timeoutId) =>
+    window.clearTimeout(timeoutId),
+  );
+  focusState.quoteTimeoutIds = [];
+}
+
+function hasCompletedTaskToday(tasks = focusState.allTasks) {
+  const now = new Date();
+  const dayStart = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  ).getTime();
+  const nextDay = dayStart + 24 * 60 * 60 * 1000;
+
+  return (
+    Array.isArray(tasks) &&
+    tasks.some((task) => {
+      if (task?.status !== "completed") return false;
+      const completedAt = new Date(task?.completedAt || 0).getTime();
+      return (
+        Number.isFinite(completedAt) &&
+        completedAt >= dayStart &&
+        completedAt < nextDay
+      );
+    })
+  );
+}
+
+function pickFocusQuote(category) {
+  const list =
+    category === "timed"
+      ? Object.values(focusQuotes.timed)
+      : focusQuotes[category];
+  if (!Array.isArray(list) || list.length === 0) return "";
+
+  const previousQuote = focusState.lastQuote[category] || null;
+  let nextQuote = list[Math.floor(Math.random() * list.length)];
+
+  if (list.length > 1 && nextQuote === previousQuote) {
+    const alternatives = list.filter((quote) => quote !== previousQuote);
+    nextQuote =
+      alternatives[Math.floor(Math.random() * alternatives.length)] ||
+      nextQuote;
+  }
+
+  focusState.lastQuote[category] = nextQuote;
+  return nextQuote;
+}
+
+function setFocusQuoteText(message, { typewriter = true } = {}) {
+  const quoteEl = getFocusQuoteEl();
+  if (!quoteEl) return;
+
+  focusState.currentQuoteToken += 1;
+  const token = focusState.currentQuoteToken;
+
+  if (focusState.quoteTypingIntervalId) {
+    window.clearInterval(focusState.quoteTypingIntervalId);
+    focusState.quoteTypingIntervalId = null;
+  }
+
+  const nextMessage = String(message || "");
+  quoteEl.textContent = "";
+
+  if (!typewriter || !nextMessage) {
+    quoteEl.classList.remove("is-typing");
+    quoteEl.textContent = nextMessage;
+    return;
+  }
+
+  quoteEl.classList.add("is-typing");
+  let index = 0;
+
+  focusState.quoteTypingIntervalId = window.setInterval(() => {
+    if (token !== focusState.currentQuoteToken) {
+      window.clearInterval(focusState.quoteTypingIntervalId);
+      focusState.quoteTypingIntervalId = null;
+      quoteEl.classList.remove("is-typing");
+      return;
     }
+
+    index += 1;
+    quoteEl.textContent = nextMessage.slice(0, index);
+
+    if (index >= nextMessage.length) {
+      window.clearInterval(focusState.quoteTypingIntervalId);
+      focusState.quoteTypingIntervalId = null;
+      quoteEl.classList.remove("is-typing");
+    }
+  }, 32);
+}
+
+function showFocusQuoteByCategory(category) {
+  const quote = pickFocusQuote(category);
+  setFocusQuoteText(quote, { typewriter: true });
+}
+
+function scheduleSessionNudges() {
+  clearFocusQuoteTimers();
+  if (!focusState.startedAt || !focusState.taskId) return;
+
+  const milestones = [
+    { offsetMs: 2 * 60 * 1000, message: focusQuotes.timed.twoMinutes },
+    { offsetMs: 5 * 60 * 1000, message: focusQuotes.timed.fiveMinutes },
+    { offsetMs: 10 * 60 * 1000, message: focusQuotes.timed.tenMinutes },
+  ];
+
+  milestones.forEach(({ offsetMs, message }) => {
+    const remainingMs = focusState.startedAt + offsetMs - Date.now();
+    if (remainingMs <= 0) return;
+
+    const timeoutId = window.setTimeout(() => {
+      if (!focusState.taskId) return;
+      setFocusQuoteText(message, { typewriter: true });
+    }, remainingMs);
+
+    focusState.quoteTimeoutIds.push(timeoutId);
+  });
 }
 
 function getFocusTasksByFilter(tasks, filter) {
-    const activeTasks = Array.isArray(tasks)
-        ? tasks.filter((task) => task.status === "active")
-        : [];
+  const activeTasks = Array.isArray(tasks)
+    ? tasks.filter((task) => task.status === "active")
+    : [];
 
-    if (filter === "big-three") {
-        return activeTasks.filter((task) => Boolean(task.isBigThree)).slice(0, 3);
-    }
+  if (filter === "big-three") {
+    return activeTasks.filter((task) => Boolean(task.isBigThree)).slice(0, 3);
+  }
 
-    if (filter === "effort") {
-        return [...activeTasks].sort((a, b) => {
-            const effortA = Number(a?.effortLevel) || 5;
-            const effortB = Number(b?.effortLevel) || 5;
-            if (effortA !== effortB) return effortA - effortB;
-
-            const createdA = new Date(a?.createdAt || 0).getTime();
-            const createdB = new Date(b?.createdAt || 0).getTime();
-            return createdB - createdA;
-        });
-    }
-
+  if (filter === "effort") {
     return [...activeTasks].sort((a, b) => {
-        const createdA = new Date(a?.createdAt || 0).getTime();
-        const createdB = new Date(b?.createdAt || 0).getTime();
-        return createdB - createdA;
+      const effortA = Number(a?.effortLevel) || 5;
+      const effortB = Number(b?.effortLevel) || 5;
+      if (effortA !== effortB) return effortA - effortB;
+
+      const createdA = new Date(a?.createdAt || 0).getTime();
+      const createdB = new Date(b?.createdAt || 0).getTime();
+      return createdB - createdA;
     });
+  }
+
+  return [...activeTasks].sort((a, b) => {
+    const createdA = new Date(a?.createdAt || 0).getTime();
+    const createdB = new Date(b?.createdAt || 0).getTime();
+    return createdB - createdA;
+  });
 }
 
 function updateFocusFilterTabs(selectedFilter, { running = false } = {}) {
-    const tabButtons = document.querySelectorAll(".focus-task-tab");
-    if (!tabButtons.length) return;
+  const tabButtons = document.querySelectorAll(".focus-task-tab");
+  if (!tabButtons.length) return;
 
-    tabButtons.forEach((buttonEl) => {
-        const isActive = buttonEl.dataset.filter === selectedFilter;
-        buttonEl.classList.toggle("is-active", isActive);
-        buttonEl.setAttribute("aria-selected", isActive ? "true" : "false");
-        buttonEl.disabled = Boolean(running);
-    });
+  tabButtons.forEach((buttonEl) => {
+    const isActive = buttonEl.dataset.filter === selectedFilter;
+    buttonEl.classList.toggle("is-active", isActive);
+    buttonEl.setAttribute("aria-selected", isActive ? "true" : "false");
+    buttonEl.disabled = Boolean(running);
+  });
 }
 
 function bindFocusFilterTabs() {
-    const tabButtons = document.querySelectorAll(".focus-task-tab");
-    if (!tabButtons.length) return;
+  const tabButtons = document.querySelectorAll(".focus-task-tab");
+  if (!tabButtons.length) return;
 
-    tabButtons.forEach((buttonEl) => {
-        buttonEl.addEventListener("click", () => {
-            if (focusState.taskId) return;
+  tabButtons.forEach((buttonEl) => {
+    buttonEl.addEventListener("click", () => {
+      if (focusState.taskId) return;
 
-            const filter = buttonEl.dataset.filter || "big-three";
-            if (filter === focusState.filter) return;
+      const filter = buttonEl.dataset.filter || "big-three";
+      if (filter === focusState.filter) return;
 
-            focusState.filter = filter;
-            updateFocusTaskOptions(focusState.allTasks);
-        });
+      focusState.filter = filter;
+      updateFocusTaskOptions(focusState.allTasks);
     });
+  });
 
-    updateFocusFilterTabs(focusState.filter, { running: Boolean(focusState.taskId) });
+  updateFocusFilterTabs(focusState.filter, {
+    running: Boolean(focusState.taskId),
+  });
 }
 
 function updateFocusModeControls({ running, hasTask } = {}) {
-    const selectEl = document.getElementById("focusTaskSelect");
-    const taskListEl = document.getElementById("focusTaskList");
-    const startBtn = document.getElementById("focusStartBtn");
-    const stopBtn = document.getElementById("focusStopBtn");
-    const completeBtn = document.getElementById("focusCompleteBtn");
-    const canStart = typeof hasTask === "boolean"
-        ? hasTask
-        : Boolean(selectEl?.value);
+  const selectEl = document.getElementById("focusTaskSelect");
+  const taskListEl = document.getElementById("focusTaskList");
+  const startBtn = document.getElementById("focusStartBtn");
+  const stopBtn = document.getElementById("focusStopBtn");
+  const completeBtn = document.getElementById("focusCompleteBtn");
+  const canStart =
+    typeof hasTask === "boolean" ? hasTask : Boolean(selectEl?.value);
 
-    if (selectEl) selectEl.disabled = running;
-    if (taskListEl) {
-        taskListEl.setAttribute("aria-disabled", Boolean(running) ? "true" : "false");
-        taskListEl.querySelectorAll(".focus-task-option").forEach((buttonEl) => {
-            buttonEl.disabled = Boolean(running);
-        });
-    }
+  if (selectEl) selectEl.disabled = running;
+  if (taskListEl) {
+    taskListEl.setAttribute(
+      "aria-disabled",
+      Boolean(running) ? "true" : "false",
+    );
+    taskListEl.querySelectorAll(".focus-task-option").forEach((buttonEl) => {
+      buttonEl.disabled = Boolean(running);
+    });
+  }
 
-    updateFocusFilterTabs(focusState.filter, { running: Boolean(running) });
+  updateFocusFilterTabs(focusState.filter, { running: Boolean(running) });
 
-    if (startBtn) {
-        startBtn.hidden = Boolean(running);
-        startBtn.disabled = Boolean(running) || !canStart;
-    }
-    if (stopBtn) {
-        stopBtn.hidden = !Boolean(running);
-        stopBtn.disabled = !Boolean(running);
-    }
-    if (completeBtn) {
-        completeBtn.hidden = !Boolean(running);
-        completeBtn.disabled = !Boolean(running);
-    }
+  if (startBtn) {
+    startBtn.hidden = Boolean(running);
+    startBtn.disabled = Boolean(running) || !canStart;
+  }
+  if (stopBtn) {
+    stopBtn.hidden = !Boolean(running);
+    stopBtn.disabled = !Boolean(running);
+  }
+  if (completeBtn) {
+    completeBtn.hidden = !Boolean(running);
+    completeBtn.disabled = !Boolean(running);
+  }
 }
 
 function syncFocusTaskSelection(taskListEl, selectedTaskId) {
-    if (!taskListEl) return;
+  if (!taskListEl) return;
 
-    const selectedValue = String(selectedTaskId || "");
-    taskListEl.querySelectorAll(".focus-task-list-item").forEach((item) => {
-        const isSelected = item.dataset.taskId === selectedValue;
-        item.classList.toggle("is-selected", isSelected);
-        item.setAttribute("aria-selected", isSelected ? "true" : "false");
-    });
+  const selectedValue = String(selectedTaskId || "");
+  taskListEl.querySelectorAll(".focus-task-list-item").forEach((item) => {
+    const isSelected = item.dataset.taskId === selectedValue;
+    item.classList.toggle("is-selected", isSelected);
+    item.setAttribute("aria-selected", isSelected ? "true" : "false");
+  });
 }
 
 function updateFocusTaskOptions(tasks) {
-    const selectEl = document.getElementById("focusTaskSelect");
-    const taskListEl = document.getElementById("focusTaskList");
-    if (!selectEl) return;
+  const selectEl = document.getElementById("focusTaskSelect");
+  const taskListEl = document.getElementById("focusTaskList");
+  if (!selectEl) return;
 
-    const previousValue = selectEl.value;
-    const filteredTasks = getFocusTasksByFilter(tasks, focusState.filter);
+  const previousValue = selectEl.value;
+  const filteredTasks = getFocusTasksByFilter(tasks, focusState.filter);
 
-    selectEl.innerHTML = "";
-    if (taskListEl) taskListEl.innerHTML = "";
+  selectEl.innerHTML = "";
+  if (taskListEl) taskListEl.innerHTML = "";
 
-    if (filteredTasks.length === 0) {
-        const option = document.createElement("option");
-        option.value = "";
-        option.textContent = "No active tasks";
-        selectEl.appendChild(option);
+  if (filteredTasks.length === 0) {
+    const option = document.createElement("option");
+    option.value = "";
+    option.textContent = "No active tasks";
+    selectEl.appendChild(option);
 
-        if (taskListEl) {
-            const emptyItem = document.createElement("li");
-            emptyItem.className = "big-three-item focus-task-empty";
-            emptyItem.textContent = "No active tasks";
-            taskListEl.appendChild(emptyItem);
-        }
-
-        updateFocusModeControls({ running: Boolean(focusState.taskId), hasTask: false });
-        return;
+    if (taskListEl) {
+      const emptyItem = document.createElement("li");
+      emptyItem.className = "big-three-item focus-task-empty";
+      emptyItem.textContent = "No active tasks";
+      taskListEl.appendChild(emptyItem);
     }
 
-    const placeholderOption = document.createElement("option");
-    placeholderOption.value = "";
-    placeholderOption.textContent = "Select a task";
-    selectEl.appendChild(placeholderOption);
-
-    filteredTasks.forEach((task) => {
-        const option = document.createElement("option");
-        const taskId = String(task._id);
-        option.value = taskId;
-        option.textContent = task.description || "Untitled task";
-        selectEl.appendChild(option);
-
-        if (taskListEl) {
-            const item = document.createElement("li");
-            item.className = "big-three-item focus-task-list-item";
-            item.dataset.taskId = taskId;
-            item.setAttribute("role", "option");
-            item.setAttribute("aria-selected", "false");
-
-            const optionButton = document.createElement("button");
-            optionButton.type = "button";
-            optionButton.className = "focus-task-option";
-            optionButton.textContent = task.description || "Untitled task";
-            optionButton.addEventListener("click", () => {
-                if (focusState.taskId) return;
-                selectEl.value = taskId;
-                syncFocusTaskSelection(taskListEl, taskId);
-                updateFocusModeControls({ running: false, hasTask: true });
-            });
-
-            item.append(optionButton);
-            taskListEl.appendChild(item);
-        }
+    updateFocusModeControls({
+      running: Boolean(focusState.taskId),
+      hasTask: false,
     });
+    return;
+  }
 
-    const runningTaskId = String(focusState.taskId || "");
-    if (runningTaskId && filteredTasks.some((task) => String(task._id) === runningTaskId)) {
-        selectEl.value = runningTaskId;
-    } else if (previousValue && filteredTasks.some((task) => String(task._id) === previousValue)) {
-        selectEl.value = previousValue;
-    } else {
-        selectEl.value = "";
+  const placeholderOption = document.createElement("option");
+  placeholderOption.value = "";
+  placeholderOption.textContent = "Select a task";
+  selectEl.appendChild(placeholderOption);
+
+  filteredTasks.forEach((task) => {
+    const option = document.createElement("option");
+    const taskId = String(task._id);
+    option.value = taskId;
+    option.textContent = task.description || "Untitled task";
+    selectEl.appendChild(option);
+
+    if (taskListEl) {
+      const item = document.createElement("li");
+      item.className = "big-three-item focus-task-list-item";
+      item.dataset.taskId = taskId;
+      item.setAttribute("role", "option");
+      item.setAttribute("aria-selected", "false");
+
+      const optionButton = document.createElement("button");
+      optionButton.type = "button";
+      optionButton.className = "focus-task-option";
+      optionButton.textContent = task.description || "Untitled task";
+      optionButton.addEventListener("click", () => {
+        if (focusState.taskId) return;
+        selectEl.value = taskId;
+        syncFocusTaskSelection(taskListEl, taskId);
+        updateFocusModeControls({ running: false, hasTask: true });
+      });
+
+      item.append(optionButton);
+      taskListEl.appendChild(item);
     }
+  });
 
-    const hasSelectedTaskInAnyList = focusState.allTasks.some(
-        (task) => task.status === "active" && String(task._id) === String(focusState.taskId)
-    );
-    if (focusState.taskId && !hasSelectedTaskInAnyList) {
-        void stopFocusSession("task_no_longer_active");
-    }
+  const runningTaskId = String(focusState.taskId || "");
+  if (
+    runningTaskId &&
+    filteredTasks.some((task) => String(task._id) === runningTaskId)
+  ) {
+    selectEl.value = runningTaskId;
+  } else if (
+    previousValue &&
+    filteredTasks.some((task) => String(task._id) === previousValue)
+  ) {
+    selectEl.value = previousValue;
+  } else {
+    selectEl.value = "";
+  }
 
-    syncFocusTaskSelection(taskListEl, selectEl.value);
-    updateFocusModeControls({ running: Boolean(focusState.taskId), hasTask: Boolean(selectEl.value) });
+  const hasSelectedTaskInAnyList = focusState.allTasks.some(
+    (task) =>
+      task.status === "active" &&
+      String(task._id) === String(focusState.taskId),
+  );
+  if (focusState.taskId && !hasSelectedTaskInAnyList) {
+    void stopFocusSession("task_no_longer_active");
+  }
+
+  syncFocusTaskSelection(taskListEl, selectEl.value);
+  updateFocusModeControls({
+    running: Boolean(focusState.taskId),
+    hasTask: Boolean(selectEl.value),
+  });
 }
 
 async function loadFocusTasks() {
-    const response = await fetch("/tasks", { credentials: "include" });
-    if (!response.ok) {
-        focusState.allTasks = [];
-        updateFocusTaskOptions([]);
-        return [];
-    }
+  const response = await fetch("/tasks", { credentials: "include" });
+  if (!response.ok) {
+    focusState.allTasks = [];
+    updateFocusTaskOptions([]);
+    return [];
+  }
 
-    const tasks = await response.json();
-    focusState.allTasks = Array.isArray(tasks) ? tasks : [];
-    updateFocusTaskOptions(focusState.allTasks);
-    return focusState.allTasks;
+  const tasks = await response.json();
+  focusState.allTasks = Array.isArray(tasks) ? tasks : [];
+  updateFocusTaskOptions(focusState.allTasks);
+  return focusState.allTasks;
 }
 
 function getFocusLogBody() {
-    return document.getElementById("focus-log-body");
+  return document.getElementById("focus-log-body");
 }
 
 function getTodayIsoRange() {
-    const now = new Date();
-    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 1);
-    return { from: start.toISOString(), to: end.toISOString() };
+  const now = new Date();
+  const start = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    0,
+    0,
+    0,
+    0,
+  );
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { from: start.toISOString(), to: end.toISOString() };
 }
 
 function computeSessionDurationMs(session) {
-    const explicitDurationMs = Number(session?.durationMs);
-    if (Number.isFinite(explicitDurationMs) && explicitDurationMs > 0) {
-        return explicitDurationMs;
-    }
+  const explicitDurationMs = Number(session?.durationMs);
+  if (Number.isFinite(explicitDurationMs) && explicitDurationMs > 0) {
+    return explicitDurationMs;
+  }
 
-    const startedAt = new Date(session?.startedAt || 0);
-    if (Number.isNaN(startedAt.getTime())) return 0;
+  const startedAt = new Date(session?.startedAt || 0);
+  if (Number.isNaN(startedAt.getTime())) return 0;
 
-    const endedAt = session?.endedAt ? new Date(session.endedAt) : new Date();
-    if (Number.isNaN(endedAt.getTime())) return 0;
+  const endedAt = session?.endedAt ? new Date(session.endedAt) : new Date();
+  if (Number.isNaN(endedAt.getTime())) return 0;
 
-    return Math.max(0, endedAt.getTime() - startedAt.getTime());
+  return Math.max(0, endedAt.getTime() - startedAt.getTime());
 }
 
 function summarizeDailyFocusSessions(sessions) {
-    const totalsByTask = new Map();
+  const totalsByTask = new Map();
 
-    sessions.forEach((session) => {
-        const taskId = String(session?.taskId || session?.taskDescription || "unknown-task");
-        const taskDescription = String(session?.taskDescription || "Deleted task").trim() || "Deleted task";
+  sessions.forEach((session) => {
+    const taskId = String(
+      session?.taskId || session?.taskDescription || "unknown-task",
+    );
+    const taskDescription =
+      String(session?.taskDescription || "Deleted task").trim() ||
+      "Deleted task";
 
-        if (!totalsByTask.has(taskId)) {
-            totalsByTask.set(taskId, {
-                taskDescription,
-                sessions: 0,
-                durationMs: 0
-            });
-        }
+    if (!totalsByTask.has(taskId)) {
+      totalsByTask.set(taskId, {
+        taskDescription,
+        sessions: 0,
+        durationMs: 0,
+      });
+    }
 
-        const entry = totalsByTask.get(taskId);
-        entry.sessions += 1;
-        entry.durationMs += computeSessionDurationMs(session);
-    });
+    const entry = totalsByTask.get(taskId);
+    entry.sessions += 1;
+    entry.durationMs += computeSessionDurationMs(session);
+  });
 
-    return Array.from(totalsByTask.values()).sort((a, b) => {
-        if (b.durationMs !== a.durationMs) return b.durationMs - a.durationMs;
-        if (b.sessions !== a.sessions) return b.sessions - a.sessions;
-        return a.taskDescription.localeCompare(b.taskDescription);
-    });
+  return Array.from(totalsByTask.values()).sort((a, b) => {
+    if (b.durationMs !== a.durationMs) return b.durationMs - a.durationMs;
+    if (b.sessions !== a.sessions) return b.sessions - a.sessions;
+    return a.taskDescription.localeCompare(b.taskDescription);
+  });
 }
 
 function formatSessionMinutes(durationMs) {
-    const minutes = Math.max(1, Math.round((Number(durationMs) || 0) / 60000));
-    return `${minutes} min`;
+  const minutes = Math.max(1, Math.round((Number(durationMs) || 0) / 60000));
+  return `${minutes} min`;
 }
 
 async function updateFocusLogWidget() {
-    const body = getFocusLogBody();
-    if (!body) return;
+  const body = getFocusLogBody();
+  if (!body) return;
 
-    const { from, to } = getTodayIsoRange();
-    const query = new URLSearchParams({ from, to }).toString();
+  const { from, to } = getTodayIsoRange();
+  const query = new URLSearchParams({ from, to }).toString();
 
-    try {
-        const response = await fetch(`/focus-sessions?${query}`, {
-            credentials: "include",
-            cache: "no-store"
-        });
-        const data = await parseApiResponse(response);
+  try {
+    const response = await fetch(`/focus-sessions?${query}`, {
+      credentials: "include",
+      cache: "no-store",
+    });
+    const data = await parseApiResponse(response);
 
-        if (!response.ok) {
-            throw new Error(data?.error || "Could not load focus sessions.");
-        }
-
-        const sessions = Array.isArray(data) ? data : [];
-        const summary = summarizeDailyFocusSessions(sessions);
-
-        if (summary.length === 0) {
-            body.innerHTML = "<p class=\"focus-log-note\">No focused tasks yet today. Start a focus session to track one.</p>";
-            return;
-        }
-
-        body.innerHTML = "";
-        const list = document.createElement("ul");
-        list.className = "focus-log-list";
-
-        summary.forEach((entry) => {
-            const sessionLabel = entry.sessions === 1 ? "session" : "sessions";
-            const item = document.createElement("li");
-            item.className = "focus-log-item";
-
-            const title = document.createElement("span");
-            title.className = "focus-log-item-title";
-            title.textContent = entry.taskDescription;
-
-            const meta = document.createElement("span");
-            meta.className = "focus-log-item-meta";
-            meta.textContent = `${entry.sessions} ${sessionLabel} - ${formatSessionMinutes(entry.durationMs)}`;
-
-            item.append(title, meta);
-            list.appendChild(item);
-        });
-
-        body.appendChild(list);
-    } catch (error) {
-        console.error("Failed to update focus log widget:", error);
-        body.innerHTML = "<p class=\"focus-log-note\">Could not load today's focus log right now.</p>";
+    if (!response.ok) {
+      throw new Error(data?.error || "Could not load focus sessions.");
     }
+
+    const sessions = Array.isArray(data) ? data : [];
+    const summary = summarizeDailyFocusSessions(sessions);
+
+    if (summary.length === 0) {
+      body.innerHTML =
+        '<p class="focus-log-note">No focused tasks yet today. Start a focus session to track one.</p>';
+      return;
+    }
+
+    body.innerHTML = "";
+    const list = document.createElement("ul");
+    list.className = "focus-log-list";
+
+    summary.forEach((entry) => {
+      const sessionLabel = entry.sessions === 1 ? "session" : "sessions";
+      const item = document.createElement("li");
+      item.className = "focus-log-item";
+
+      const title = document.createElement("span");
+      title.className = "focus-log-item-title";
+      title.textContent = entry.taskDescription;
+
+      const meta = document.createElement("span");
+      meta.className = "focus-log-item-meta";
+      meta.textContent = `${entry.sessions} ${sessionLabel} - ${formatSessionMinutes(entry.durationMs)}`;
+
+      item.append(title, meta);
+      list.appendChild(item);
+    });
+
+    body.appendChild(list);
+  } catch (error) {
+    console.error("Failed to update focus log widget:", error);
+    body.innerHTML =
+      '<p class="focus-log-note">Could not load today\'s focus log right now.</p>';
+  }
 }
 
 async function stopFocusSession(reason = "manual_stop") {
-    const statusEl = document.getElementById("focus-status");
-    const isRunning = Boolean(focusState.taskId);
-    const apiReason = ["completed_task", "manual_stop", "timeout", "app_closed"].includes(reason)
-        ? reason
-        : "manual_stop";
-    let stopError = null;
+  const statusEl = document.getElementById("focus-status");
+  const isRunning = Boolean(focusState.taskId);
+  const endingTaskId = focusState.taskId;
+  const endedTask = focusState.allTasks.find(
+    (task) => String(task?._id) === String(endingTaskId),
+  );
+  const taskMarkedCompleted = endedTask?.status === "completed";
+  const apiReason = [
+    "completed_task",
+    "manual_stop",
+    "timeout",
+    "app_closed",
+  ].includes(reason)
+    ? reason
+    : "manual_stop";
+  let stopError = null;
 
-    if (isRunning) {
-        try {
-            const response = await fetch("/focus-sessions/stop", {
-                credentials: "include",
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ reason: apiReason })
-            });
-
-            if (!response.ok && response.status !== 404) {
-                const payload = await parseApiResponse(response);
-                stopError = payload?.error || "Could not save focus session.";
-            }
-        } catch (error) {
-            console.error("Stop focus session request failed:", error);
-            stopError = "Could not save focus session.";
-        }
-    }
-
-    stopFocusTimer();
-    focusState.taskId = null;
-    focusState.sessionId = null;
-    focusState.startedAt = null;
-    updateFocusModeControls({ running: false });
-    renderFocusTimer();
-
-    if (isRunning) {
-        await updateFocusLogWidget();
-    }
-
-    if (!statusEl || !isRunning) return;
-
-    if (reason === "completed_task") {
-        statusEl.textContent = "Focus session ended because this task was completed.";
-    } else if (reason === "task_no_longer_active") {
-        statusEl.textContent = "Focus session ended because the task is no longer active.";
-    } else {
-        statusEl.textContent = "Focus session stopped.";
-    }
-
-    if (stopError) {
-        Toast.show({ message: stopError, type: "error", duration: 3000 });
-    }
-}
-
-
-async function completeTask(taskId) {
-    if (!taskId) return { ok: false, error: "Select a task first." };
-
-    const task = focusState.allTasks.find((entry) => String(entry?._id) === String(taskId));
-    const payload = { status: "completed" };
-    if (Boolean(task?.isBigThree)) {
-        payload.isBigThree = false;
-    }
-
+  if (isRunning) {
     try {
-        const updateResponse = await fetch(`/tasks/${taskId}`, {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(payload)
-        });
-        const updateData = await parseApiResponse(updateResponse);
-        if (!updateResponse.ok) {
-            return { ok: false, error: updateData?.error || "Could not complete task." };
-        }
-
-        return { ok: true };
-    } catch (error) {
-        console.error("Completing focus task failed:", error);
-        return { ok: false, error: "Could not complete task." };
-    }
-}
-
-async function initFocusMode() {
-    const selectEl = document.getElementById("focusTaskSelect");
-    const startBtn = document.getElementById("focusStartBtn");
-    const stopBtn = document.getElementById("focusStopBtn");
-    const completeBtn = document.getElementById("focusCompleteBtn");
-    const statusEl = document.getElementById("focus-status");
-    if (!selectEl || !startBtn || !stopBtn || !completeBtn || !statusEl) return;
-
-    bindFocusFilterTabs();
-
-    try {
-        await loadFocusTasks();
-    } catch (error) {
-        console.error("Focus task preload failed:", error);
-        updateFocusTaskOptions([]);
-    }
-
-    startBtn.addEventListener("click", async () => {
-        const selectedTaskId = selectEl.value;
-        const selectedTaskLabel = selectEl.options[selectEl.selectedIndex]?.text || "";
-        if (!selectedTaskId) {
-            Toast.show({ message: "Select a task before starting focus mode.", type: "error", duration: 2500 });
-            return;
-        }
-
-        if (focusState.taskId) {
-            return;
-        }
-
-        startBtn.disabled = true;
-
-        try {
-            const response = await fetch("/focus-sessions/start", {
-                credentials: "include",
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ taskId: selectedTaskId })
-            });
-            const payload = await parseApiResponse(response);
-
-            if (!response.ok) {
-                Toast.show({ message: payload?.error || "Could not start focus session.", type: "error", duration: 3000 });
-                return;
-            }
-
-            const parsedStartedAt = new Date(payload?.startedAt || Date.now());
-
-            focusState.sessionId = payload?._id || null;
-            focusState.taskId = selectedTaskId;
-            focusState.startedAt = Number.isNaN(parsedStartedAt.getTime())
-                ? Date.now()
-                : parsedStartedAt.getTime();
-            updateFocusModeControls({ running: true, hasTask: true });
-            startFocusTimer();
-            statusEl.textContent = `Focused on: ${selectedTaskLabel}`;
-            await updateFocusLogWidget();
-        } catch (error) {
-            console.error("Start focus session request failed:", error);
-            Toast.show({ message: "Could not start focus session.", type: "error", duration: 3000 });
-        } finally {
-            if (!focusState.taskId) {
-                updateFocusModeControls({ running: false, hasTask: Boolean(selectEl.value) });
-            }
-        }
-    });
-
-    stopBtn.addEventListener("click", async () => {
-        await stopFocusSession("manual_stop");
-    });
-
-    completeBtn.addEventListener("click", async () => {
-        if (!focusState.taskId) return;
-
-        completeBtn.disabled = true;
-        stopBtn.disabled = true;
-
-        const completion = await completeTask(focusState.taskId);
-        if (!completion.ok) {
-            Toast.show({ message: completion.error, type: "error", duration: 3000 });
-            updateFocusModeControls({ running: Boolean(focusState.taskId), hasTask: Boolean(selectEl.value) });
-            return;
-        }
-
-        await stopFocusSession("completed_task");
-        await loadFocusTasks();
-    });
-}
-
-document.addEventListener("DOMContentLoaded", () => {
-    console.log("DOM Fully Loaded - JavaScript Running");
-
-    // Page flags let us adjust behavior for standalone login/register views
-    const isLoginPage = document.body.classList.contains("login-page");
-    const isRegisterPage = document.body.classList.contains("register-page");
-    const currentPath = window.location.pathname;
-    const protectedPaths = new Set([
-        "/dashboard.html",
-        "/calendar-page.html",
-        "/profile-page.html",
-        "/settings-page.html",
-        "/feedback-page.html"
-    ]);
-    const isProtectedPage = protectedPaths.has(currentPath);
-    const isHomePage = currentPath === "/" || currentPath === "/index.html";
-
-    // Registration handler (used on register.html)
-    const registerForm = document.getElementById("registerForm");
-    if (registerForm) {
-        registerForm.addEventListener("submit", async (event) => {
-            event.preventDefault();
-
-            const firstName = document.getElementById("registerFirstName")?.value.trim();
-            const lastName = document.getElementById("registerLastName")?.value.trim();
-            const email = document.getElementById("registerEmail")?.value.trim();
-            const password = document.getElementById("registerPassword").value;
-            const confirmPassword = document.getElementById("registerConfirm").value;
-
-            if (!firstName || !lastName || !email) {
-                
-                alert("Please fill in first name, last name, and email.");
-                return;
-            }
-
-
-            // Simple client-side guard to match the confirm password box
-            if (password !== confirmPassword) {
-                alert("Passwords do not match.");
-                return;
-            }
-
-           
-
-            try {
-                const response = await fetch("/register", {
-                    credentials: "include",
-                    method: "POST",
-                    headers: { "Content-Type": "application/json"},
-                    body: JSON.stringify({ firstName, lastName, email, password })
-                });
-
-                const data = await parseApiResponse(response);
-
-                // Check if registration went alright
-                if (response.ok) {
-                    const sentFlag = data?.emailDeliveryFailed ? "0" : "1";
-                    const query = new URLSearchParams({ sent: sentFlag, email }).toString();
-                    window.location.href = `/verification-status.html?${query}`;
-                } else {
-                    alert("Registration failed: " + (data.error || "Unknown error"));
-                }
-            } catch (error) {
-                console.error("Registration request failed:", error);
-                alert("Registration failed due to a network/server issue.");
-            }
-        });
-    }
-
-
-    const verificationPage = document.getElementById("verification-status-page");
-    if (verificationPage) {
-        const params = new URLSearchParams(window.location.search);
-        const sent = params.get("sent") === "1";
-        const email = (params.get("email") || "").trim();
-
-        const messageEl = document.getElementById("verificationStatusMessage");
-        const emailEl = document.getElementById("verificationStatusEmail");
-        const resendBtn = document.getElementById("resendVerificationBtn");
-
-        if (messageEl) {
-            messageEl.textContent = sent
-                ? "Verification email was sent."
-                : "Verification email was not sent.";
-        }
-
-        if (emailEl) {
-            emailEl.textContent = email ? `Email: ${email}` : "Email unavailable";
-        }
-
-        resendBtn?.addEventListener("click", async () => {
-            if (!email) {
-                alert("No email found for this registration. Please sign up again.");
-                return;
-            }
-
-            resendBtn.disabled = true;
-
-            try {
-                const response = await fetch("/resend-verification", {
-                    credentials: "include",
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ email })
-                });
-
-                const data = await parseApiResponse(response);
-                if (response.ok) {
-                    alert(data.message || "Verification email sent.");
-                    Toast.show({ message: "Verification email resent", type: "success", duration: 2200 });
-                } else {
-                    alert(data.error || "Could not resend verification email.");
-                    Toast.show({ message: "Resend failed", type: "error", duration: 2200 });
-                }
-            } catch (error) {
-                console.error("Resend verification request failed:", error);
-                alert("Network error while resending verification email.");
-            } finally {
-                resendBtn.disabled = false;
-            }
-        });
-    }
-
-
-    const forgotPasswordForm = document.getElementById("forgotPasswordForm");
-    if (forgotPasswordForm) {
-        forgotPasswordForm.addEventListener("submit", async (event) => {
-            event.preventDefault();
-            const email = document.getElementById("forgotPasswordEmail")?.value.trim();
-
-            if (!email) {
-                alert("Please enter your email.");
-                return;
-            }
-
-            try {
-                const response = await fetch("/forgot-password", {
-                    credentials: "include",
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ email })
-                });
-
-                const data = await parseApiResponse(response);
-                if (response.ok) {
-                    alert(data.message || "If that account exists, a password reset email has been sent.");
-                    Toast.show({ message: "Reset email request sent", type: "success", duration: 2400 });
-                } else {
-                    alert(data.error || "Could not process reset request.");
-                }
-            } catch (error) {
-                console.error("Forgot password request failed:", error);
-                alert("Network error while requesting password reset.");
-            }
-        });
-    }
-
-    const resetPasswordForm = document.getElementById("resetPasswordForm");
-    if (resetPasswordForm) {
-        const params = new URLSearchParams(window.location.search);
-        const emailInput = document.getElementById("resetPasswordEmail");
-        const tokenInput = document.getElementById("resetPasswordToken");
-
-        if (emailInput && params.get("email")) emailInput.value = params.get("email");
-        if (tokenInput && params.get("token")) tokenInput.value = params.get("token");
-
-        resetPasswordForm.addEventListener("submit", async (event) => {
-            event.preventDefault();
-
-            const email = emailInput?.value.trim();
-            const token = tokenInput?.value.trim();
-            const newPassword = document.getElementById("resetPasswordNew")?.value || "";
-            const confirmPassword = document.getElementById("resetPasswordConfirm")?.value || "";
-
-            if (!email || !token || !newPassword) {
-                alert("Please complete all required fields.");
-                return;
-            }
-
-            if (newPassword !== confirmPassword) {
-                alert("Passwords do not match.");
-                return;
-            }
-
-            try {
-                const response = await fetch("/reset-password", {
-                    credentials: "include",
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ email, token, newPassword })
-                });
-
-                const data = await parseApiResponse(response);
-                if (response.ok) {
-                    alert(data.message || "Password reset successful.");
-                    Toast.show({ message: "Password updated", type: "success", duration: 2200 });
-                    window.location.href = "/login.html";
-                } else {
-                    alert(data.error || "Unable to reset password.");
-                }
-            } catch (error) {
-                console.error("Reset password request failed:", error);
-                alert("Network error while resetting password.");
-            }
-        });
-    }
-
-    // Login handler (used on login.html)
-    const loginForm = document.getElementById("loginForm");
-    if (loginForm) {
-        loginForm.addEventListener("submit", async (event) => {
-            event.preventDefault();
-        
-            const email = document.getElementById("loginEmail").value.trim();
-            const password = document.getElementById("loginPassword").value;
-            const rememberMe = document.getElementById("rememberMe")?.checked || false;
-
-            try {
-                const response = await fetch("/login", {
-                    credentials: "include",
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ email, password, rememberMe })
-                });
-            
-                
-                const data = await parseApiResponse(response);
-            
-                if (response.ok) {
-                    // alert("Login successful!");
-                    Toast.show({ message: "Login Sucessful", type: "success", duration: 2000 });
-                    // Auth pages should move you to the dashboard once logged in
-                    window.location.href = "/dashboard.html";
-                    
-                } else {
-                    alert("Login failed: " + (data.error || "Unknown error"));
-                    Toast.show({ message: "Login failed: " + (data.error || "Unknown error"), type: "error", duration: 4000 });
-                }
-            } catch (error) {
-                console.error("Login request failed:", error);
-                alert("Login failed due to a network/server issue.");
-                Toast.show({ message: "Login failed due to a network/server issue.", type: "error", duration: 2000 });
-            }
-        });
-    }
-
-    // Function to log out a user (dashboard only)
-    const logoutBtn = document.getElementById("logoutBtn");
-    if (logoutBtn) {
-        logoutBtn.addEventListener("click", async (event) => {
-            event.preventDefault();
-
-            try {
-                const response = await fetch("/logout", {
-                    credentials: "include",
-                    method: "POST"
-                });
-
-                if (response.ok) {
-                    Toast.show({ message: "Logged out successfully", type: "success", duration: 2000 });
-                    // Send the user back to login after logout
-                    window.location.href = "/login.html";
-                } else {
-                    const data = await parseApiResponse(response);
-                    alert("Logout failed: " + (data.error || "Unknown error"));
-                }
-            } catch (error) {
-                console.error("Logout request failed:", error);
-                alert("Logout failed due to a network/server issue.");
-            }
-        });
-    }
-
-    // Task Submission Form
-    // const submitBtn = document.getElementById("submitBtn");
-    // if (submitBtn) {
-    //     submitBtn.onclick = submit;
-    // }
-    const taskForm = document.getElementById("taskForm");
-    if (taskForm) {
-        taskForm.addEventListener("submit", submit);
-    }
-
-    const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
-    if (clearCompletedButton) {
-        clearCompletedButton.addEventListener("click", clearCompletedTasks);
-    }
-
-    bindDashboardTaskFilterTabs();
-
-    checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
-    initFocusMode();
-});
-
-
-async function updateNavTaskCounter() {
-    const counters = document.querySelectorAll(".item-counter");
-    if (!counters.length) return;
-
-    try {
-        const response = await fetch("/tasks", { credentials: "include" });
-        if (!response.ok) return;
-
-        const tasks = await response.json();
-        const activeCount = Array.isArray(tasks)
-            ? tasks.filter((task) => task.status === "active").length
-            : 0;
-
-        counters.forEach((el) => {
-            el.textContent = String(activeCount);
-        });
-    } catch (error) {
-        console.error("Error updating nav task counter:", error);
-    }
-}
-
-// Function to check if a user is currently logged in
-async function checkAuthStatus({ isLoginPage = false, isRegisterPage = false, isProtectedPage = false, isHomePage = false } = {}) {
-    const authSection = document.getElementById("auth-section");
-    const mainSection = document.getElementById("main-section");
-    const authStatus = document.getElementById("authStatus");
-    const logoutBtn = document.getElementById("logoutBtn");
-
-    let data = { loggedIn: false };
-
-    try {
-        const response = await fetch("/auth-status", {
-            credentials: "include",
-            cache: "no-store"
-        });
-
-        data = await parseApiResponse(response);
-    } catch (error) {
-        console.error("Auth status check failed:", error);
-    }
-
-    if (data.loggedIn) {
-        if (isHomePage) {
-            window.location.href = "/dashboard.html";
-            return;
-        }
-
-        // Keep login/register pages from showing when already authenticated
-        if (isLoginPage || isRegisterPage) {
-            window.location.href = "/dashboard.html";
-            return;
-        }
-
-        if (authStatus) {
-            //Choose randomly from a set of welcome back messages
-
-            // const messages = [
-            //     "Ready when you are",
-            //     "Time to tackle your tasks",
-            //     "Ready to be productive",
-            //     "Your tasks await",
-            //     "Let's make today productive"
-            // ];
-            // const randomIndex = Math.floor(Math.random() * messages.length);
-            // const welcomeMessage = messages[randomIndex];
-            // authStatus.textContent += `${welcomeMessage} ${data.user.firstName}`;
-
-            const rawName = String(data?.user?.firstName || data?.user?.name || "").trim();
-            const firstName = rawName.split(/\s+/)[0] || "there";
-            authStatus.textContent = `Welcome back, ${firstName}`;
-
-        }
-        authSection?.classList.add("hidden"); // Hide login/register CTA on dashboard
-        mainSection?.classList.remove("hidden"); // Show main task page
-        if (logoutBtn) {
-            logoutBtn.style.display = "block";
-        }
-        if (mainSection) {
-            fetchTasks(); // Automatically load tasks if user is logged in
-        }
-        updateFocusLogWidget();
-
-        updateNavTaskCounter();
-    } else {
-        // Protected pages should send logged-out users to login instead of showing a blank shell.
-        if (isProtectedPage) {
-            window.location.href = "/login.html";
-            return;
-        }
-
-        // Only toggle dashboard sections if they are present on the page
-        if (authStatus) {
-            authStatus.textContent = "Not logged in";
-        }
-        authSection?.classList.remove("hidden"); // Show login/register CTA
-        mainSection?.classList.add("hidden"); // Hide main task page
-        if (logoutBtn) {
-            logoutBtn.style.display = "none";
-        }
-        const taskList = document.querySelector(".task-list");
-        if (taskList) {
-            taskList.innerHTML = ""; // Clear tasks when logged out
-        }
-    }
-}
-
-
-// Function to get the tasks for the logged in user
-async function fetchTasks() {
-    const response = await fetch("/tasks", { credentials: "include" });
-    const tasks = await response.json();
-
-    if (response.ok) {
-        dashboardTaskState.allTasks = Array.isArray(tasks) ? tasks : [];
-        updateTaskList(dashboardTaskState.allTasks);
-    } else {
-        console.error("Error fetching tasks:", tasks.error);
-        alert("Please log in to see your tasks.");
-    }
-}
-
-async function clearCompletedTasks() {
-    const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
-
-    if (clearCompletedButton) {
-        clearCompletedButton.disabled = true;
-    }
-
-    try {
-        const response = await fetch("/tasks", { credentials: "include" });
-        const tasks = await parseApiResponse(response);
-
-        if (!response.ok) {
-            Toast.show({ message: tasks?.error || "Could not load tasks.", type: "error", duration: 3000 });
-            return;
-        }
-
-        const completedTasks = Array.isArray(tasks)
-            ? tasks.filter((task) => task.status === "completed")
-            : [];
-
-        if (completedTasks.length === 0) {
-            Toast.show({ message: "No completed tasks to clear.", type: "error", duration: 2200 });
-            return;
-        }
-
-        const deleteResults = await Promise.allSettled(
-            completedTasks.map((task) => fetch(`/tasks/${task._id}`, { method: "DELETE" }))
-        );
-
-        const deletedCount = deleteResults.filter((result) => result.status === "fulfilled" && result.value.ok).length;
-
-        if (deletedCount === completedTasks.length) {
-            Toast.show({ message: "Cleared completed tasks", type: "success", duration: 2500 });
-        } else if (deletedCount > 0) {
-            Toast.show({ message: `Cleared ${deletedCount} completed tasks. Some could not be deleted.`, type: "error", duration: 3500 });
-        } else {
-            Toast.show({ message: "Could not clear completed tasks.", type: "error", duration: 3000 });
-        }
-
-        fetchTasks();
-    } catch (error) {
-        console.error("Clearing completed tasks failed:", error);
-        Toast.show({ message: "Could not clear completed tasks.", type: "error", duration: 3000 });
-    } finally {
-        if (clearCompletedButton) {
-            clearCompletedButton.disabled = false;
-        }
-    }
-}
-
-// Function to submit a task (User must be logged in)
-const submit = async function(event) {
-    Toast.show({ message: "Task Submitted", type: "success", duration: 2000 });
-    event.preventDefault(); // Stop default form submission behavior
-
-    const taskInput = document.querySelector("#taskDescription");
-    const dateInput = document.querySelector("#dueDate");
-    const effortInput = document.querySelector('input[name="effortLevel"]:checked');
-
-    // Create JSON object with form data
-    const dueDateValue = dateInput.value.trim();
-    const json = {
-    description: taskInput.value.trim(),
-    dueDate: dueDateValue || null,
-    effortLevel: effortInput ? parseInt(effortInput.value, 10) : 3
-    };
-
-    if (!json.description) {
-    alert("Please enter a task description.");
-    return;
-    }
-
-
-    // Send task data to the server
-    const response = await fetch("/tasks", {
+      const response = await fetch("/focus-sessions/stop", {
         credentials: "include",
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(json)
+        body: JSON.stringify({ reason: apiReason }),
+      });
+
+      if (!response.ok && response.status !== 404) {
+        const payload = await parseApiResponse(response);
+        stopError = payload?.error || "Could not save focus session.";
+      }
+    } catch (error) {
+      console.error("Stop focus session request failed:", error);
+      stopError = "Could not save focus session.";
+    }
+  }
+
+  stopFocusTimer();
+  clearFocusQuoteTimers();
+  focusState.taskId = null;
+  focusState.sessionId = null;
+  focusState.startedAt = null;
+  updateFocusModeControls({ running: false });
+  renderFocusTimer();
+
+  if (isRunning) {
+    await updateFocusLogWidget();
+  }
+
+  if (!statusEl || !isRunning) return;
+
+  if (reason === "completed_task" || taskMarkedCompleted) {
+    statusEl.textContent =
+      "Focus session ended because this task was completed.";
+    showFocusQuoteByCategory("completion");
+  } else if (reason === "task_no_longer_active") {
+    statusEl.textContent =
+      "Focus session ended because the task is no longer active.";
+  } else {
+    statusEl.textContent = "Focus session stopped.";
+  }
+
+  if (stopError) {
+    Toast.show({ message: stopError, type: "error", duration: 3000 });
+  }
+}
+
+async function completeTask(taskId) {
+  if (!taskId) return { ok: false, error: "Select a task first." };
+
+  const task = focusState.allTasks.find(
+    (entry) => String(entry?._id) === String(taskId),
+  );
+  const payload = { status: "completed" };
+  if (Boolean(task?.isBigThree)) {
+    payload.isBigThree = false;
+  }
+
+  try {
+    const updateResponse = await fetch(`/tasks/${taskId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
     });
-
-    const data = await response.json();
-
-    if (response.ok) {
-        console.log("Task added successfully:", data);
-        updateTaskList(data); // Refresh task list
-    } else {
-        console.error("Task Submission Error:", data.error);
-        alert("You must be logged in to submit tasks.");
+    const updateData = await parseApiResponse(updateResponse);
+    if (!updateResponse.ok) {
+      return {
+        ok: false,
+        error: updateData?.error || "Could not complete task.",
+      };
     }
 
-    // Clear input fields after submission
-    taskInput.value = "";
-    dateInput.value = "";
+    return { ok: true };
+  } catch (error) {
+    console.error("Completing focus task failed:", error);
+    return { ok: false, error: "Could not complete task." };
+  }
+}
+
+async function initFocusMode() {
+  const selectEl = document.getElementById("focusTaskSelect");
+  const startBtn = document.getElementById("focusStartBtn");
+  const stopBtn = document.getElementById("focusStopBtn");
+  const completeBtn = document.getElementById("focusCompleteBtn");
+  const statusEl = document.getElementById("focus-status");
+  if (!selectEl || !startBtn || !stopBtn || !completeBtn || !statusEl) return;
+
+  bindFocusFilterTabs();
+  setFocusQuoteText("", { typewriter: false });
+
+  try {
+    await loadFocusTasks();
+  } catch (error) {
+    console.error("Focus task preload failed:", error);
+    updateFocusTaskOptions([]);
+  }
+
+  window.setTimeout(() => {
+    showFocusQuoteByCategory("general");
+  }, 220);
+
+  startBtn.addEventListener("click", async () => {
+    const selectedTaskId = selectEl.value;
+    const selectedTaskLabel =
+      selectEl.options[selectEl.selectedIndex]?.text || "";
+    if (!selectedTaskId) {
+      Toast.show({
+        message: "Select a task before starting focus mode.",
+        type: "error",
+        duration: 2500,
+      });
+      return;
+    }
+
+    if (focusState.taskId) {
+      return;
+    }
+
+    startBtn.disabled = true;
+
+    try {
+      const response = await fetch("/focus-sessions/start", {
+        credentials: "include",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ taskId: selectedTaskId }),
+      });
+      const payload = await parseApiResponse(response);
+
+      if (!response.ok) {
+        Toast.show({
+          message: payload?.error || "Could not start focus session.",
+          type: "error",
+          duration: 3000,
+        });
+        return;
+      }
+
+      const parsedStartedAt = new Date(payload?.startedAt || Date.now());
+
+      focusState.sessionId = payload?._id || null;
+      focusState.taskId = selectedTaskId;
+      focusState.startedAt = Number.isNaN(parsedStartedAt.getTime())
+        ? Date.now()
+        : parsedStartedAt.getTime();
+      updateFocusModeControls({ running: true, hasTask: true });
+      startFocusTimer();
+      const quoteCategory = hasCompletedTaskToday() ? "persistence" : "general";
+      showFocusQuoteByCategory(quoteCategory);
+      scheduleSessionNudges();
+      statusEl.textContent = `Focused on: ${selectedTaskLabel}`;
+      await updateFocusLogWidget();
+    } catch (error) {
+      console.error("Start focus session request failed:", error);
+      Toast.show({
+        message: "Could not start focus session.",
+        type: "error",
+        duration: 3000,
+      });
+    } finally {
+      if (!focusState.taskId) {
+        updateFocusModeControls({
+          running: false,
+          hasTask: Boolean(selectEl.value),
+        });
+      }
+    }
+  });
+
+  stopBtn.addEventListener("click", async () => {
+    await stopFocusSession("manual_stop");
+  });
+
+  completeBtn.addEventListener("click", async () => {
+    if (!focusState.taskId) return;
+
+    completeBtn.disabled = true;
+    stopBtn.disabled = true;
+
+    const completion = await completeTask(focusState.taskId);
+    if (!completion.ok) {
+      Toast.show({ message: completion.error, type: "error", duration: 3000 });
+      updateFocusModeControls({
+        running: Boolean(focusState.taskId),
+        hasTask: Boolean(selectEl.value),
+      });
+      return;
+    }
+
+    await stopFocusSession("completed_task");
+    await loadFocusTasks();
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  console.log("DOM Fully Loaded - JavaScript Running");
+
+  // Page flags let us adjust behavior for standalone login/register views
+  const isLoginPage = document.body.classList.contains("login-page");
+  const isRegisterPage = document.body.classList.contains("register-page");
+  const currentPath = window.location.pathname;
+  const protectedPaths = new Set([
+    "/dashboard.html",
+    "/calendar-page.html",
+    "/profile-page.html",
+    "/settings-page.html",
+    "/feedback-page.html",
+  ]);
+  const isProtectedPage = protectedPaths.has(currentPath);
+  const isHomePage = currentPath === "/" || currentPath === "/index.html";
+
+  // Registration handler (used on register.html)
+  const registerForm = document.getElementById("registerForm");
+  if (registerForm) {
+    registerForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+
+      const firstName = document
+        .getElementById("registerFirstName")
+        ?.value.trim();
+      const lastName = document
+        .getElementById("registerLastName")
+        ?.value.trim();
+      const email = document.getElementById("registerEmail")?.value.trim();
+      const password = document.getElementById("registerPassword").value;
+      const confirmPassword = document.getElementById("registerConfirm").value;
+
+      if (!firstName || !lastName || !email) {
+        alert("Please fill in first name, last name, and email.");
+        return;
+      }
+
+      // Simple client-side guard to match the confirm password box
+      if (password !== confirmPassword) {
+        alert("Passwords do not match.");
+        return;
+      }
+
+      try {
+        const response = await fetch("/register", {
+          credentials: "include",
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ firstName, lastName, email, password }),
+        });
+
+        const data = await parseApiResponse(response);
+
+        // Check if registration went alright
+        if (response.ok) {
+          const sentFlag = data?.emailDeliveryFailed ? "0" : "1";
+          const query = new URLSearchParams({
+            sent: sentFlag,
+            email,
+          }).toString();
+          window.location.href = `/verification-status.html?${query}`;
+        } else {
+          alert("Registration failed: " + (data.error || "Unknown error"));
+        }
+      } catch (error) {
+        console.error("Registration request failed:", error);
+        alert("Registration failed due to a network/server issue.");
+      }
+    });
+  }
+
+  const verificationPage = document.getElementById("verification-status-page");
+  if (verificationPage) {
+    const params = new URLSearchParams(window.location.search);
+    const sent = params.get("sent") === "1";
+    const email = (params.get("email") || "").trim();
+
+    const messageEl = document.getElementById("verificationStatusMessage");
+    const emailEl = document.getElementById("verificationStatusEmail");
+    const resendBtn = document.getElementById("resendVerificationBtn");
+
+    if (messageEl) {
+      messageEl.textContent = sent
+        ? "Verification email was sent."
+        : "Verification email was not sent.";
+    }
+
+    if (emailEl) {
+      emailEl.textContent = email ? `Email: ${email}` : "Email unavailable";
+    }
+
+    resendBtn?.addEventListener("click", async () => {
+      if (!email) {
+        alert("No email found for this registration. Please sign up again.");
+        return;
+      }
+
+      resendBtn.disabled = true;
+
+      try {
+        const response = await fetch("/resend-verification", {
+          credentials: "include",
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email }),
+        });
+
+        const data = await parseApiResponse(response);
+        if (response.ok) {
+          alert(data.message || "Verification email sent.");
+          Toast.show({
+            message: "Verification email resent",
+            type: "success",
+            duration: 2200,
+          });
+        } else {
+          alert(data.error || "Could not resend verification email.");
+          Toast.show({
+            message: "Resend failed",
+            type: "error",
+            duration: 2200,
+          });
+        }
+      } catch (error) {
+        console.error("Resend verification request failed:", error);
+        alert("Network error while resending verification email.");
+      } finally {
+        resendBtn.disabled = false;
+      }
+    });
+  }
+
+  const forgotPasswordForm = document.getElementById("forgotPasswordForm");
+  if (forgotPasswordForm) {
+    forgotPasswordForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const email = document
+        .getElementById("forgotPasswordEmail")
+        ?.value.trim();
+
+      if (!email) {
+        alert("Please enter your email.");
+        return;
+      }
+
+      try {
+        const response = await fetch("/forgot-password", {
+          credentials: "include",
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email }),
+        });
+
+        const data = await parseApiResponse(response);
+        if (response.ok) {
+          alert(
+            data.message ||
+              "If that account exists, a password reset email has been sent.",
+          );
+          Toast.show({
+            message: "Reset email request sent",
+            type: "success",
+            duration: 2400,
+          });
+        } else {
+          alert(data.error || "Could not process reset request.");
+        }
+      } catch (error) {
+        console.error("Forgot password request failed:", error);
+        alert("Network error while requesting password reset.");
+      }
+    });
+  }
+
+  const resetPasswordForm = document.getElementById("resetPasswordForm");
+  if (resetPasswordForm) {
+    const params = new URLSearchParams(window.location.search);
+    const emailInput = document.getElementById("resetPasswordEmail");
+    const tokenInput = document.getElementById("resetPasswordToken");
+
+    if (emailInput && params.get("email"))
+      emailInput.value = params.get("email");
+    if (tokenInput && params.get("token"))
+      tokenInput.value = params.get("token");
+
+    resetPasswordForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+
+      const email = emailInput?.value.trim();
+      const token = tokenInput?.value.trim();
+      const newPassword =
+        document.getElementById("resetPasswordNew")?.value || "";
+      const confirmPassword =
+        document.getElementById("resetPasswordConfirm")?.value || "";
+
+      if (!email || !token || !newPassword) {
+        alert("Please complete all required fields.");
+        return;
+      }
+
+      if (newPassword !== confirmPassword) {
+        alert("Passwords do not match.");
+        return;
+      }
+
+      try {
+        const response = await fetch("/reset-password", {
+          credentials: "include",
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, token, newPassword }),
+        });
+
+        const data = await parseApiResponse(response);
+        if (response.ok) {
+          alert(data.message || "Password reset successful.");
+          Toast.show({
+            message: "Password updated",
+            type: "success",
+            duration: 2200,
+          });
+          window.location.href = "/login.html";
+        } else {
+          alert(data.error || "Unable to reset password.");
+        }
+      } catch (error) {
+        console.error("Reset password request failed:", error);
+        alert("Network error while resetting password.");
+      }
+    });
+  }
+
+  // Login handler (used on login.html)
+  const loginForm = document.getElementById("loginForm");
+  if (loginForm) {
+    loginForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+
+      const email = document.getElementById("loginEmail").value.trim();
+      const password = document.getElementById("loginPassword").value;
+      const rememberMe =
+        document.getElementById("rememberMe")?.checked || false;
+
+      try {
+        const response = await fetch("/login", {
+          credentials: "include",
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, password, rememberMe }),
+        });
+
+        const data = await parseApiResponse(response);
+
+        if (response.ok) {
+          // alert("Login successful!");
+          Toast.show({
+            message: "Login Sucessful",
+            type: "success",
+            duration: 2000,
+          });
+          // Auth pages should move you to the dashboard once logged in
+          window.location.href = "/dashboard.html";
+        } else {
+          alert("Login failed: " + (data.error || "Unknown error"));
+          Toast.show({
+            message: "Login failed: " + (data.error || "Unknown error"),
+            type: "error",
+            duration: 4000,
+          });
+        }
+      } catch (error) {
+        console.error("Login request failed:", error);
+        alert("Login failed due to a network/server issue.");
+        Toast.show({
+          message: "Login failed due to a network/server issue.",
+          type: "error",
+          duration: 2000,
+        });
+      }
+    });
+  }
+
+  // Function to log out a user (dashboard only)
+  const logoutBtn = document.getElementById("logoutBtn");
+  if (logoutBtn) {
+    logoutBtn.addEventListener("click", async (event) => {
+      event.preventDefault();
+
+      try {
+        const response = await fetch("/logout", {
+          credentials: "include",
+          method: "POST",
+        });
+
+        if (response.ok) {
+          Toast.show({
+            message: "Logged out successfully",
+            type: "success",
+            duration: 2000,
+          });
+          // Send the user back to login after logout
+          window.location.href = "/login.html";
+        } else {
+          const data = await parseApiResponse(response);
+          alert("Logout failed: " + (data.error || "Unknown error"));
+        }
+      } catch (error) {
+        console.error("Logout request failed:", error);
+        alert("Logout failed due to a network/server issue.");
+      }
+    });
+  }
+
+  // Task Submission Form
+  // const submitBtn = document.getElementById("submitBtn");
+  // if (submitBtn) {
+  //     submitBtn.onclick = submit;
+  // }
+  const taskForm = document.getElementById("taskForm");
+  if (taskForm) {
+    taskForm.addEventListener("submit", submit);
+  }
+
+  const clearCompletedButton = document.getElementById(
+    "clear-completed-tasks-btn",
+  );
+  if (clearCompletedButton) {
+    clearCompletedButton.addEventListener("click", clearCompletedTasks);
+  }
+
+  bindDashboardTaskFilterTabs();
+
+  checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
+  initFocusMode();
+});
+
+async function updateNavTaskCounter() {
+  const counters = document.querySelectorAll(".item-counter");
+  if (!counters.length) return;
+
+  try {
+    const response = await fetch("/tasks", { credentials: "include" });
+    if (!response.ok) return;
+
+    const tasks = await response.json();
+    const activeCount = Array.isArray(tasks)
+      ? tasks.filter((task) => task.status === "active").length
+      : 0;
+
+    counters.forEach((el) => {
+      el.textContent = String(activeCount);
+    });
+  } catch (error) {
+    console.error("Error updating nav task counter:", error);
+  }
+}
+
+// Function to check if a user is currently logged in
+async function checkAuthStatus({
+  isLoginPage = false,
+  isRegisterPage = false,
+  isProtectedPage = false,
+  isHomePage = false,
+} = {}) {
+  const authSection = document.getElementById("auth-section");
+  const mainSection = document.getElementById("main-section");
+  const authStatus = document.getElementById("authStatus");
+  const logoutBtn = document.getElementById("logoutBtn");
+
+  let data = { loggedIn: false };
+
+  try {
+    const response = await fetch("/auth-status", {
+      credentials: "include",
+      cache: "no-store",
+    });
+
+    data = await parseApiResponse(response);
+  } catch (error) {
+    console.error("Auth status check failed:", error);
+  }
+
+  if (data.loggedIn) {
+    if (isHomePage) {
+      window.location.href = "/dashboard.html";
+      return;
+    }
+
+    // Keep login/register pages from showing when already authenticated
+    if (isLoginPage || isRegisterPage) {
+      window.location.href = "/dashboard.html";
+      return;
+    }
+
+    if (authStatus) {
+      //Choose randomly from a set of welcome back messages
+
+      // const messages = [
+      //     "Ready when you are",
+      //     "Time to tackle your tasks",
+      //     "Ready to be productive",
+      //     "Your tasks await",
+      //     "Let's make today productive"
+      // ];
+      // const randomIndex = Math.floor(Math.random() * messages.length);
+      // const welcomeMessage = messages[randomIndex];
+      // authStatus.textContent += `${welcomeMessage} ${data.user.firstName}`;
+
+      const rawName = String(
+        data?.user?.firstName || data?.user?.name || "",
+      ).trim();
+      const firstName = rawName.split(/\s+/)[0] || "there";
+      authStatus.textContent = `Welcome back, ${firstName}`;
+    }
+    authSection?.classList.add("hidden"); // Hide login/register CTA on dashboard
+    mainSection?.classList.remove("hidden"); // Show main task page
+    if (logoutBtn) {
+      logoutBtn.style.display = "block";
+    }
+    if (mainSection) {
+      fetchTasks(); // Automatically load tasks if user is logged in
+    }
+    updateFocusLogWidget();
+
+    updateNavTaskCounter();
+  } else {
+    // Protected pages should send logged-out users to login instead of showing a blank shell.
+    if (isProtectedPage) {
+      window.location.href = "/login.html";
+      return;
+    }
+
+    // Only toggle dashboard sections if they are present on the page
+    if (authStatus) {
+      authStatus.textContent = "Not logged in";
+    }
+    authSection?.classList.remove("hidden"); // Show login/register CTA
+    mainSection?.classList.add("hidden"); // Hide main task page
+    if (logoutBtn) {
+      logoutBtn.style.display = "none";
+    }
+    const taskList = document.querySelector(".task-list");
+    if (taskList) {
+      taskList.innerHTML = ""; // Clear tasks when logged out
+    }
+  }
+}
+
+// Function to get the tasks for the logged in user
+async function fetchTasks() {
+  const response = await fetch("/tasks", { credentials: "include" });
+  const tasks = await response.json();
+
+  if (response.ok) {
+    dashboardTaskState.allTasks = Array.isArray(tasks) ? tasks : [];
+    updateTaskList(dashboardTaskState.allTasks);
+  } else {
+    console.error("Error fetching tasks:", tasks.error);
+    alert("Please log in to see your tasks.");
+  }
+}
+
+async function clearCompletedTasks() {
+  const clearCompletedButton = document.getElementById(
+    "clear-completed-tasks-btn",
+  );
+
+  if (clearCompletedButton) {
+    clearCompletedButton.disabled = true;
+  }
+
+  try {
+    const response = await fetch("/tasks", { credentials: "include" });
+    const tasks = await parseApiResponse(response);
+
+    if (!response.ok) {
+      Toast.show({
+        message: tasks?.error || "Could not load tasks.",
+        type: "error",
+        duration: 3000,
+      });
+      return;
+    }
+
+    const completedTasks = Array.isArray(tasks)
+      ? tasks.filter((task) => task.status === "completed")
+      : [];
+
+    if (completedTasks.length === 0) {
+      Toast.show({
+        message: "No completed tasks to clear.",
+        type: "error",
+        duration: 2200,
+      });
+      return;
+    }
+
+    const deleteResults = await Promise.allSettled(
+      completedTasks.map((task) =>
+        fetch(`/tasks/${task._id}`, { method: "DELETE" }),
+      ),
+    );
+
+    const deletedCount = deleteResults.filter(
+      (result) => result.status === "fulfilled" && result.value.ok,
+    ).length;
+
+    if (deletedCount === completedTasks.length) {
+      Toast.show({
+        message: "Cleared completed tasks",
+        type: "success",
+        duration: 2500,
+      });
+    } else if (deletedCount > 0) {
+      Toast.show({
+        message: `Cleared ${deletedCount} completed tasks. Some could not be deleted.`,
+        type: "error",
+        duration: 3500,
+      });
+    } else {
+      Toast.show({
+        message: "Could not clear completed tasks.",
+        type: "error",
+        duration: 3000,
+      });
+    }
+
+    fetchTasks();
+  } catch (error) {
+    console.error("Clearing completed tasks failed:", error);
+    Toast.show({
+      message: "Could not clear completed tasks.",
+      type: "error",
+      duration: 3000,
+    });
+  } finally {
+    if (clearCompletedButton) {
+      clearCompletedButton.disabled = false;
+    }
+  }
+}
+
+// Function to submit a task (User must be logged in)
+const submit = async function (event) {
+  Toast.show({ message: "Task Submitted", type: "success", duration: 2000 });
+  event.preventDefault(); // Stop default form submission behavior
+
+  const taskInput = document.querySelector("#taskDescription");
+  const dateInput = document.querySelector("#dueDate");
+  const effortInput = document.querySelector(
+    'input[name="effortLevel"]:checked',
+  );
+
+  // Create JSON object with form data
+  const dueDateValue = dateInput.value.trim();
+  const json = {
+    description: taskInput.value.trim(),
+    dueDate: dueDateValue || null,
+    effortLevel: effortInput ? parseInt(effortInput.value, 10) : 3,
+  };
+
+  if (!json.description) {
+    alert("Please enter a task description.");
+    return;
+  }
+
+  // Send task data to the server
+  const response = await fetch("/tasks", {
+    credentials: "include",
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(json),
+  });
+
+  const data = await response.json();
+
+  if (response.ok) {
+    console.log("Task added successfully:", data);
+    updateTaskList(data); // Refresh task list
+  } else {
+    console.error("Task Submission Error:", data.error);
+    alert("You must be logged in to submit tasks.");
+  }
+
+  // Clear input fields after submission
+  taskInput.value = "";
+  dateInput.value = "";
 };
 
 function setBigThreeButtonState(button, isBigThree) {
-    if (!button) return;
+  if (!button) return;
 
-    const icon = button.querySelector("i");
-    const active = Boolean(isBigThree);
+  const icon = button.querySelector("i");
+  const active = Boolean(isBigThree);
 
-    button.classList.toggle("is-active", active);
-    button.setAttribute("aria-pressed", active ? "true" : "false");
-    button.title = active ? "Remove from Big 3" : "Add to Big 3";
+  button.classList.toggle("is-active", active);
+  button.setAttribute("aria-pressed", active ? "true" : "false");
+  button.title = active ? "Remove from Big 3" : "Add to Big 3";
 
-    if (icon) {
-        icon.classList.toggle("fa-solid", active);
-        icon.classList.toggle("fa-regular", !active);
-        icon.style.color = "rgba(237, 28, 28, 1.00)";
-    }
+  if (icon) {
+    icon.classList.toggle("fa-solid", active);
+    icon.classList.toggle("fa-regular", !active);
+    icon.style.color = "rgba(237, 28, 28, 1.00)";
+  }
 }
 
 function updateBigThreeWidget(tasks, taskInteractions = new Map()) {
-    const bigThreeList = document.getElementById("big-three-list");
-    const emptyState = document.querySelector("#big-3-tasks .big-three-empty");
-    if (!bigThreeList || !emptyState) return;
+  const bigThreeList = document.getElementById("big-three-list");
+  const emptyState = document.querySelector("#big-3-tasks .big-three-empty");
+  if (!bigThreeList || !emptyState) return;
 
-    const bigThreeTasks = tasks.filter((task) => task.isBigThree).slice(0, 3);
-    bigThreeList.innerHTML = "";
+  const bigThreeTasks = tasks.filter((task) => task.isBigThree).slice(0, 3);
+  bigThreeList.innerHTML = "";
 
-    if (bigThreeTasks.length === 0) {
-        emptyState.hidden = false;
-        bigThreeList.hidden = true;
-        return;
+  if (bigThreeTasks.length === 0) {
+    emptyState.hidden = false;
+    bigThreeList.hidden = true;
+    return;
+  }
+
+  emptyState.hidden = true;
+  bigThreeList.hidden = false;
+
+  bigThreeTasks.forEach((task, index) => {
+    const item = document.createElement("li");
+    item.className = "big-three-item";
+
+    const interactions = taskInteractions.get(task._id) || {};
+
+    const completeInput = document.createElement("input");
+    completeInput.type = "checkbox";
+    completeInput.className = "task-check big-three-check";
+    completeInput.checked = task.status === "completed";
+    completeInput.setAttribute("aria-label", `Mark task ${index + 1} complete`);
+
+    if (typeof interactions.toggleComplete === "function") {
+      completeInput.addEventListener("change", async () => {
+        completeInput.disabled = true;
+        const isCompleted = completeInput.checked;
+        const updated = await interactions.toggleComplete(isCompleted);
+        if (!updated) {
+          completeInput.checked = !isCompleted;
+        }
+        completeInput.disabled = false;
+      });
+    } else {
+      completeInput.disabled = true;
     }
 
-    emptyState.hidden = true;
-    bigThreeList.hidden = false;
+    const descriptionButton = document.createElement("button");
+    descriptionButton.type = "button";
+    descriptionButton.className = "big-three-details-trigger";
+    descriptionButton.textContent = `${index + 1}. ${task.description}`;
+    descriptionButton.title = "Open task details";
 
-    bigThreeTasks.forEach((task, index) => {
-        const item = document.createElement("li");
-        item.className = "big-three-item";
+    if (typeof interactions.openTaskDetails === "function") {
+      descriptionButton.addEventListener("click", interactions.openTaskDetails);
+    } else {
+      descriptionButton.disabled = true;
+    }
 
-        const interactions = taskInteractions.get(task._id) || {};
-
-        const completeInput = document.createElement("input");
-        completeInput.type = "checkbox";
-        completeInput.className = "task-check big-three-check";
-        completeInput.checked = task.status === "completed";
-        completeInput.setAttribute("aria-label", `Mark task ${index + 1} complete`);
-
-        if (typeof interactions.toggleComplete === "function") {
-            completeInput.addEventListener("change", async () => {
-                completeInput.disabled = true;
-                const isCompleted = completeInput.checked;
-                const updated = await interactions.toggleComplete(isCompleted);
-                if (!updated) {
-                    completeInput.checked = !isCompleted;
-                }
-                completeInput.disabled = false;
-            });
-        } else {
-            completeInput.disabled = true;
-        }
-
-        const descriptionButton = document.createElement("button");
-        descriptionButton.type = "button";
-        descriptionButton.className = "big-three-details-trigger";
-        descriptionButton.textContent = `${index + 1}. ${task.description}`;
-        descriptionButton.title = "Open task details";
-
-        if (typeof interactions.openTaskDetails === "function") {
-            descriptionButton.addEventListener("click", interactions.openTaskDetails);
-        } else {
-            descriptionButton.disabled = true;
-        }
-
-        item.append(completeInput, descriptionButton);
-        bigThreeList.appendChild(item);
-    });
+    item.append(completeInput, descriptionButton);
+    bigThreeList.appendChild(item);
+  });
 }
-
-
 
 let activeTaskInPanel = null;
 let panelTypewriterRunId = 0;
 
 function toDisplayDate(value) {
-    if (!value) return null;
+  if (!value) return null;
 
-    if (typeof value === "string") {
-        const match = value.trim().match(/^(\d{4})-(\d{2})-(\d{2})$/);
-        if (match) {
-            const year = parseInt(match[1], 10);
-            const month = parseInt(match[2], 10);
-            const day = parseInt(match[3], 10);
-            return new Date(year, month - 1, day, 12, 0, 0, 0);
-        }
+  if (typeof value === "string") {
+    const match = value.trim().match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (match) {
+      const year = parseInt(match[1], 10);
+      const month = parseInt(match[2], 10);
+      const day = parseInt(match[3], 10);
+      return new Date(year, month - 1, day, 12, 0, 0, 0);
     }
+  }
 
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? null : date;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
 function formatTaskDueDate(dueDate) {
-    const date = toDisplayDate(dueDate);
-    if (!date) return "No due date";
-    return `Due: ${date.toLocaleDateString()}`;
+  const date = toDisplayDate(dueDate);
+  if (!date) return "No due date";
+  return `Due: ${date.toLocaleDateString()}`;
 }
 
 function formatTaskEffortLevel(effortLevel) {
-    const safeEffort = Math.max(1, Math.min(5, parseInt(effortLevel, 10) || 3));
-    return `${safeEffort} / 5`;
+  const safeEffort = Math.max(1, Math.min(5, parseInt(effortLevel, 10) || 3));
+  return `${safeEffort} / 5`;
 }
 
-
-
 function wait(ms) {
-    return new Promise((resolve) => window.setTimeout(resolve, ms));
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
 async function typeTextIntoElement(element, text, runId, speedMs = 20) {
-    if (!element) return;
+  if (!element) return;
 
-    const value = String(text || "");
-    element.textContent = "";
+  const value = String(text || "");
+  element.textContent = "";
 
-    for (let index = 0; index < value.length; index += 1) {
-        if (runId !== panelTypewriterRunId) return;
-        element.textContent += value[index];
-        await wait(speedMs);
-    }
+  for (let index = 0; index < value.length; index += 1) {
+    if (runId !== panelTypewriterRunId) return;
+    element.textContent += value[index];
+    await wait(speedMs);
+  }
 }
 
 async function animateTaskDetailFields(task, runId) {
-    const descriptionEl = document.getElementById("panelTaskDescription");
-    const dueDateEl = document.getElementById("panelTaskDueDate");
-    const effortEl = document.getElementById("panelTaskEffort");
-    if (!descriptionEl || !dueDateEl || !effortEl) return;
+  const descriptionEl = document.getElementById("panelTaskDescription");
+  const dueDateEl = document.getElementById("panelTaskDueDate");
+  const effortEl = document.getElementById("panelTaskEffort");
+  if (!descriptionEl || !dueDateEl || !effortEl) return;
 
-    const descriptionText = task.description || "No description";
-    const dueDateText = formatTaskDueDate(task.dueDate);
-    const effortText = formatTaskEffortLevel(task.effortLevel);
+  const descriptionText = task.description || "No description";
+  const dueDateText = formatTaskDueDate(task.dueDate);
+  const effortText = formatTaskEffortLevel(task.effortLevel);
 
-    await typeTextIntoElement(descriptionEl, descriptionText, runId, 18);
-    await typeTextIntoElement(dueDateEl, dueDateText, runId, 16);
-    await typeTextIntoElement(effortEl, effortText, runId, 16);
+  await typeTextIntoElement(descriptionEl, descriptionText, runId, 18);
+  await typeTextIntoElement(dueDateEl, dueDateText, runId, 16);
+  await typeTextIntoElement(effortEl, effortText, runId, 16);
 }
 
 function formatDateInputValue(dueDate) {
-    if (!dueDate) return "";
-    const date = new Date(dueDate);
-    if (Number.isNaN(date.getTime())) return "";
+  if (!dueDate) return "";
+  const date = new Date(dueDate);
+  if (Number.isNaN(date.getTime())) return "";
 
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}-${month}-${day}`;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 function setPanelEffortInputValue(effortLevel) {
-    const safeEffort = Math.max(1, Math.min(5, parseInt(effortLevel, 10) || 3));
-    document.querySelectorAll('input[name="panelEffortLevel"]').forEach((radio) => {
-        radio.checked = parseInt(radio.value, 10) === safeEffort;
+  const safeEffort = Math.max(1, Math.min(5, parseInt(effortLevel, 10) || 3));
+  document
+    .querySelectorAll('input[name="panelEffortLevel"]')
+    .forEach((radio) => {
+      radio.checked = parseInt(radio.value, 10) === safeEffort;
     });
 }
 
 function getPanelEffortInputValue() {
-    const checked = document.querySelector('input[name="panelEffortLevel"]:checked');
-    return checked ? parseInt(checked.value, 10) : 3;
+  const checked = document.querySelector(
+    'input[name="panelEffortLevel"]:checked',
+  );
+  return checked ? parseInt(checked.value, 10) : 3;
 }
 
 function setTaskDetailEditMode(task, isEditing) {
-    const panelEditButton = document.getElementById("panelEditBtn");
-    const descriptionDisplay = document.getElementById("panelTaskDescription");
-    const dueDateDisplay = document.getElementById("panelTaskDueDate");
-    const effortDisplay = document.getElementById("panelTaskEffort");
-    const descriptionInput = document.getElementById("panelTaskDescriptionInput");
-    const dueDateInput = document.getElementById("panelTaskDueDateInput");
-    const effortInput = document.getElementById("panelTaskEffortInput");
+  const panelEditButton = document.getElementById("panelEditBtn");
+  const descriptionDisplay = document.getElementById("panelTaskDescription");
+  const dueDateDisplay = document.getElementById("panelTaskDueDate");
+  const effortDisplay = document.getElementById("panelTaskEffort");
+  const descriptionInput = document.getElementById("panelTaskDescriptionInput");
+  const dueDateInput = document.getElementById("panelTaskDueDateInput");
+  const effortInput = document.getElementById("panelTaskEffortInput");
 
-    if (!panelEditButton || !descriptionDisplay || !dueDateDisplay || !effortDisplay || !descriptionInput || !dueDateInput || !effortInput) {
-        return;
-    }
+  if (
+    !panelEditButton ||
+    !descriptionDisplay ||
+    !dueDateDisplay ||
+    !effortDisplay ||
+    !descriptionInput ||
+    !dueDateInput ||
+    !effortInput
+  ) {
+    return;
+  }
 
-    descriptionDisplay.hidden = isEditing;
-    dueDateDisplay.hidden = isEditing;
-    effortDisplay.hidden = isEditing;
+  descriptionDisplay.hidden = isEditing;
+  dueDateDisplay.hidden = isEditing;
+  effortDisplay.hidden = isEditing;
 
-    descriptionInput.hidden = !isEditing;
-    dueDateInput.hidden = !isEditing;
-    effortInput.hidden = !isEditing;
+  descriptionInput.hidden = !isEditing;
+  dueDateInput.hidden = !isEditing;
+  effortInput.hidden = !isEditing;
 
-    const editLabel = panelEditButton.querySelector("span");
-    const editIcon = panelEditButton.querySelector("i");
-    if (editLabel) {
-        editLabel.textContent = isEditing ? "Save" : "Edit";
-    }
-    if (editIcon) {
-        editIcon.className = isEditing ? "fa-solid fa-floppy-disk" : "fa-solid fa-pen-to-square";
-    }
+  const editLabel = panelEditButton.querySelector("span");
+  const editIcon = panelEditButton.querySelector("i");
+  if (editLabel) {
+    editLabel.textContent = isEditing ? "Save" : "Edit";
+  }
+  if (editIcon) {
+    editIcon.className = isEditing
+      ? "fa-solid fa-floppy-disk"
+      : "fa-solid fa-pen-to-square";
+  }
 
-    if (isEditing) {
-        descriptionInput.value = task.description || "";
-        dueDateInput.value = formatDateInputValue(task.dueDate);
-        setPanelEffortInputValue(task.effortLevel);
-        descriptionInput.focus();
-    }
+  if (isEditing) {
+    descriptionInput.value = task.description || "";
+    dueDateInput.value = formatDateInputValue(task.dueDate);
+    setPanelEffortInputValue(task.effortLevel);
+    descriptionInput.focus();
+  }
 }
 
-async function updateTaskCompletionStatus(task, isCompleted, taskCheck, taskItem, controls = {}) {
-    const nextStatus = isCompleted ? "completed" : "active";
-    const shouldRemoveBigThree = isCompleted && Boolean(task.isBigThree);
+async function updateTaskCompletionStatus(
+  task,
+  isCompleted,
+  taskCheck,
+  taskItem,
+  controls = {},
+) {
+  const nextStatus = isCompleted ? "completed" : "active";
+  const shouldRemoveBigThree = isCompleted && Boolean(task.isBigThree);
 
-    try {
-        const payload = { status: nextStatus };
-        if (shouldRemoveBigThree) {
-            payload.isBigThree = false;
-        }
-
-        const updateResponse = await fetch(`/tasks/${task._id}`, {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(payload)
-        });
-
-        if (!updateResponse.ok) {
-            console.error("Error updating task status");
-            return false;
-        }
-
-        task.status = nextStatus;
-
-        if (shouldRemoveBigThree) {
-            task.isBigThree = false;
-            setBigThreeButtonState(controls.bigThreeButton, false);
-            setBigThreeButtonState(controls.panelBigThreeButton, false);
-        }
-
-        if (taskCheck) {
-            taskCheck.checked = isCompleted;
-        }
-        taskItem?.classList.toggle("is-completed", isCompleted);
-
-        if (nextStatus === "completed") {
-            Toast.show({ message: "Task Completed! One step down, time for the next.", type: "success", duration: 4000 });
-        }
-
-        fetchTasks();
-        return true;
-    } catch (error) {
-        console.error("Task status update failed:", error);
-        return false;
+  try {
+    const payload = { status: nextStatus };
+    if (shouldRemoveBigThree) {
+      payload.isBigThree = false;
     }
+
+    const updateResponse = await fetch(`/tasks/${task._id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!updateResponse.ok) {
+      console.error("Error updating task status");
+      return false;
+    }
+
+    task.status = nextStatus;
+
+    if (shouldRemoveBigThree) {
+      task.isBigThree = false;
+      setBigThreeButtonState(controls.bigThreeButton, false);
+      setBigThreeButtonState(controls.panelBigThreeButton, false);
+    }
+
+    if (taskCheck) {
+      taskCheck.checked = isCompleted;
+    }
+    taskItem?.classList.toggle("is-completed", isCompleted);
+
+    if (nextStatus === "completed") {
+      Toast.show({
+        message: "Task Completed! One step down, time for the next.",
+        type: "success",
+        duration: 4000,
+      });
+    }
+
+    fetchTasks();
+    return true;
+  } catch (error) {
+    console.error("Task status update failed:", error);
+    return false;
+  }
 }
 
 function closeTaskDetailPanel() {
-    const panel = document.getElementById("task-detail-panel");
-    const backdrop = document.getElementById("task-detail-backdrop");
-    if (!panel || !backdrop) return;
+  const panel = document.getElementById("task-detail-panel");
+  const backdrop = document.getElementById("task-detail-backdrop");
+  if (!panel || !backdrop) return;
 
-    panel.classList.remove("is-open");
-    panel.setAttribute("aria-hidden", "true");
-    backdrop.classList.remove("is-visible");
-    backdrop.setAttribute("aria-hidden", "true");
-    document.body.classList.remove("task-panel-open");
+  panel.classList.remove("is-open");
+  panel.setAttribute("aria-hidden", "true");
+  backdrop.classList.remove("is-visible");
+  backdrop.setAttribute("aria-hidden", "true");
+  document.body.classList.remove("task-panel-open");
 
-    const effortInput = document.getElementById("panelTaskEffortInput");
-    if (effortInput) {
-        effortInput.hidden = true;
-    }
+  const effortInput = document.getElementById("panelTaskEffortInput");
+  if (effortInput) {
+    effortInput.hidden = true;
+  }
 
-    const panelEditButton = document.getElementById("panelEditBtn");
-    const editLabel = panelEditButton?.querySelector("span");
-    const editIcon = panelEditButton?.querySelector("i");
-    if (editLabel) editLabel.textContent = "Edit";
-    if (editIcon) editIcon.className = "fa-solid fa-pen-to-square";
+  const panelEditButton = document.getElementById("panelEditBtn");
+  const editLabel = panelEditButton?.querySelector("span");
+  const editIcon = panelEditButton?.querySelector("i");
+  if (editLabel) editLabel.textContent = "Edit";
+  if (editIcon) editIcon.className = "fa-solid fa-pen-to-square";
 
-    panelTypewriterRunId += 1;
-    activeTaskInPanel = null;
+  panelTypewriterRunId += 1;
+  activeTaskInPanel = null;
 }
 
 function wireTaskDetailPanel() {
-    const panel = document.getElementById("task-detail-panel");
-    const backdrop = document.getElementById("task-detail-backdrop");
-    const closeButton = document.getElementById("taskDetailClose");
-    if (!panel || !backdrop || !closeButton || panel.dataset.ready === "true") return;
+  const panel = document.getElementById("task-detail-panel");
+  const backdrop = document.getElementById("task-detail-backdrop");
+  const closeButton = document.getElementById("taskDetailClose");
+  if (!panel || !backdrop || !closeButton || panel.dataset.ready === "true")
+    return;
 
-    const panelBigThreeButton = document.getElementById("panelBigThreeBtn");
-    const panelEditButton = document.getElementById("panelEditBtn");
-    const panelDeleteButton = document.getElementById("panelDeleteBtn");
-    const panelTaskComplete = document.getElementById("panelTaskComplete");
+  const panelBigThreeButton = document.getElementById("panelBigThreeBtn");
+  const panelEditButton = document.getElementById("panelEditBtn");
+  const panelDeleteButton = document.getElementById("panelDeleteBtn");
+  const panelTaskComplete = document.getElementById("panelTaskComplete");
 
-    closeButton.addEventListener("click", closeTaskDetailPanel);
-    backdrop.addEventListener("click", closeTaskDetailPanel);
+  closeButton.addEventListener("click", closeTaskDetailPanel);
+  backdrop.addEventListener("click", closeTaskDetailPanel);
 
-    document.addEventListener("keydown", (event) => {
-        if (event.key === "Escape" && panel.classList.contains("is-open")) {
-            closeTaskDetailPanel();
-        }
-    });
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && panel.classList.contains("is-open")) {
+      closeTaskDetailPanel();
+    }
+  });
 
-    panelBigThreeButton?.addEventListener("click", () => activeTaskInPanel?.toggleBigThree?.());
-    panelEditButton?.addEventListener("click", () => activeTaskInPanel?.handleEditOrSave?.());
-    panelDeleteButton?.addEventListener("click", () => activeTaskInPanel?.deleteTask?.());
-    panelTaskComplete?.addEventListener("change", () => activeTaskInPanel?.toggleComplete?.());
+  panelBigThreeButton?.addEventListener("click", () =>
+    activeTaskInPanel?.toggleBigThree?.(),
+  );
+  panelEditButton?.addEventListener("click", () =>
+    activeTaskInPanel?.handleEditOrSave?.(),
+  );
+  panelDeleteButton?.addEventListener("click", () =>
+    activeTaskInPanel?.deleteTask?.(),
+  );
+  panelTaskComplete?.addEventListener("change", () =>
+    activeTaskInPanel?.toggleComplete?.(),
+  );
 
-    panel.dataset.ready = "true";
+  panel.dataset.ready = "true";
 }
 
 function openTaskDetailPanel(task, handlers) {
-    const panel = document.getElementById("task-detail-panel");
-    const backdrop = document.getElementById("task-detail-backdrop");
-    const descriptionEl = document.getElementById("panelTaskDescription");
-    const dueDateEl = document.getElementById("panelTaskDueDate");
-    const effortEl = document.getElementById("panelTaskEffort");
-    const panelBigThreeButton = document.getElementById("panelBigThreeBtn");
-    const panelTaskComplete = document.getElementById("panelTaskComplete");
-    const panelDescriptionInput = document.getElementById("panelTaskDescriptionInput");
-    const panelDueDateInput = document.getElementById("panelTaskDueDateInput");
-    const panelEffortInput = document.getElementById("panelTaskEffortInput");
-    if (!panel || !backdrop || !descriptionEl || !dueDateEl || !effortEl || !panelBigThreeButton || !panelTaskComplete || !panelDescriptionInput || !panelDueDateInput || !panelEffortInput) return;
+  const panel = document.getElementById("task-detail-panel");
+  const backdrop = document.getElementById("task-detail-backdrop");
+  const descriptionEl = document.getElementById("panelTaskDescription");
+  const dueDateEl = document.getElementById("panelTaskDueDate");
+  const effortEl = document.getElementById("panelTaskEffort");
+  const panelBigThreeButton = document.getElementById("panelBigThreeBtn");
+  const panelTaskComplete = document.getElementById("panelTaskComplete");
+  const panelDescriptionInput = document.getElementById(
+    "panelTaskDescriptionInput",
+  );
+  const panelDueDateInput = document.getElementById("panelTaskDueDateInput");
+  const panelEffortInput = document.getElementById("panelTaskEffortInput");
+  if (
+    !panel ||
+    !backdrop ||
+    !descriptionEl ||
+    !dueDateEl ||
+    !effortEl ||
+    !panelBigThreeButton ||
+    !panelTaskComplete ||
+    !panelDescriptionInput ||
+    !panelDueDateInput ||
+    !panelEffortInput
+  )
+    return;
 
-    wireTaskDetailPanel();
+  wireTaskDetailPanel();
 
-    panelTypewriterRunId += 1;
-    const currentRunId = panelTypewriterRunId;
-    descriptionEl.textContent = "";
-    dueDateEl.textContent = "";
-    effortEl.textContent = "";
-    animateTaskDetailFields(task, currentRunId);
+  panelTypewriterRunId += 1;
+  const currentRunId = panelTypewriterRunId;
+  descriptionEl.textContent = "";
+  dueDateEl.textContent = "";
+  effortEl.textContent = "";
+  animateTaskDetailFields(task, currentRunId);
 
-    setBigThreeButtonState(panelBigThreeButton, task.isBigThree);
-    panelBigThreeButton.disabled = false;
-    panelTaskComplete.checked = task.status === "completed";
+  setBigThreeButtonState(panelBigThreeButton, task.isBigThree);
+  panelBigThreeButton.disabled = false;
+  panelTaskComplete.checked = task.status === "completed";
 
-    let isEditing = false;
-    setTaskDetailEditMode(task, false);
+  let isEditing = false;
+  setTaskDetailEditMode(task, false);
 
-    activeTaskInPanel = {
-        ...handlers,
-        syncBigThree(nextValue) {
-            task.isBigThree = nextValue;
-            setBigThreeButtonState(panelBigThreeButton, nextValue);
-        },
-        syncCompletion(nextStatus) {
-            task.status = nextStatus;
-            panelTaskComplete.checked = nextStatus === "completed";
-        },
-        async handleEditOrSave() {
-            if (!isEditing) {
-                isEditing = true;
-                setTaskDetailEditMode(task, true);
-                return;
-            }
+  activeTaskInPanel = {
+    ...handlers,
+    syncBigThree(nextValue) {
+      task.isBigThree = nextValue;
+      setBigThreeButtonState(panelBigThreeButton, nextValue);
+    },
+    syncCompletion(nextStatus) {
+      task.status = nextStatus;
+      panelTaskComplete.checked = nextStatus === "completed";
+    },
+    async handleEditOrSave() {
+      if (!isEditing) {
+        isEditing = true;
+        setTaskDetailEditMode(task, true);
+        return;
+      }
 
-            const nextDescription = panelDescriptionInput.value.trim();
-            const nextDueDate = panelDueDateInput.value || null;
-            const nextEffortLevel = getPanelEffortInputValue();
+      const nextDescription = panelDescriptionInput.value.trim();
+      const nextDueDate = panelDueDateInput.value || null;
+      const nextEffortLevel = getPanelEffortInputValue();
 
-            if (!nextDescription) {
-                Toast.show({ message: "Task description cannot be empty.", type: "error", duration: 3000 });
-                return;
-            }
+      if (!nextDescription) {
+        Toast.show({
+          message: "Task description cannot be empty.",
+          type: "error",
+          duration: 3000,
+        });
+        return;
+      }
 
-            const savedTask = await handlers.saveTaskEdits?.({
-                description: nextDescription,
-                dueDate: nextDueDate,
-                effortLevel: nextEffortLevel
-            });
+      const savedTask = await handlers.saveTaskEdits?.({
+        description: nextDescription,
+        dueDate: nextDueDate,
+        effortLevel: nextEffortLevel,
+      });
 
-            if (!savedTask) return;
+      if (!savedTask) return;
 
-            task.description = savedTask.description ?? nextDescription;
-            task.dueDate = savedTask.dueDate ?? nextDueDate;
-            task.effortLevel = savedTask.effortLevel ?? nextEffortLevel;
+      task.description = savedTask.description ?? nextDescription;
+      task.dueDate = savedTask.dueDate ?? nextDueDate;
+      task.effortLevel = savedTask.effortLevel ?? nextEffortLevel;
 
-            isEditing = false;
-            setTaskDetailEditMode(task, false);
+      isEditing = false;
+      setTaskDetailEditMode(task, false);
 
-            panelTypewriterRunId += 1;
-            const updatedRunId = panelTypewriterRunId;
-            descriptionEl.textContent = "";
-            dueDateEl.textContent = "";
-            effortEl.textContent = "";
-            animateTaskDetailFields(task, updatedRunId);
-        }
-    };
+      panelTypewriterRunId += 1;
+      const updatedRunId = panelTypewriterRunId;
+      descriptionEl.textContent = "";
+      dueDateEl.textContent = "";
+      effortEl.textContent = "";
+      animateTaskDetailFields(task, updatedRunId);
+    },
+  };
 
-    panel.classList.add("is-open");
-    panel.setAttribute("aria-hidden", "false");
-    backdrop.classList.add("is-visible");
-    backdrop.setAttribute("aria-hidden", "false");
-    document.body.classList.add("task-panel-open");
+  panel.classList.add("is-open");
+  panel.setAttribute("aria-hidden", "false");
+  backdrop.classList.add("is-visible");
+  backdrop.setAttribute("aria-hidden", "false");
+  document.body.classList.add("task-panel-open");
 }
 
 function getTaskDueSortTimestamp(dueDate) {
-    if (!dueDate) return Number.POSITIVE_INFINITY;
-    const parsedDate = new Date(dueDate);
-    if (Number.isNaN(parsedDate.getTime())) return Number.POSITIVE_INFINITY;
-    return parsedDate.getTime();
+  if (!dueDate) return Number.POSITIVE_INFINITY;
+  const parsedDate = new Date(dueDate);
+  if (Number.isNaN(parsedDate.getTime())) return Number.POSITIVE_INFINITY;
+  return parsedDate.getTime();
 }
 
 function getDashboardTasksByFilter(tasks, filter = "task-list") {
-    const safeTasks = Array.isArray(tasks) ? tasks.slice() : [];
+  const safeTasks = Array.isArray(tasks) ? tasks.slice() : [];
 
-    return safeTasks.sort((a, b) => {
-        const aCompleted = a.status === "completed";
-        const bCompleted = b.status === "completed";
+  return safeTasks.sort((a, b) => {
+    const aCompleted = a.status === "completed";
+    const bCompleted = b.status === "completed";
 
-        if (aCompleted !== bCompleted) {
-            return aCompleted ? 1 : -1;
-        }
+    if (aCompleted !== bCompleted) {
+      return aCompleted ? 1 : -1;
+    }
 
-        if (filter === "effort") {
-            const effortA = Number(a?.effortLevel) || 5;
-            const effortB = Number(b?.effortLevel) || 5;
-            if (effortA !== effortB) return effortA - effortB;
-        } else if (filter === "due-date") {
-            const dueA = getTaskDueSortTimestamp(a?.dueDate);
-            const dueB = getTaskDueSortTimestamp(b?.dueDate);
-            if (dueA !== dueB) return dueA - dueB;
-        }
+    if (filter === "effort") {
+      const effortA = Number(a?.effortLevel) || 5;
+      const effortB = Number(b?.effortLevel) || 5;
+      if (effortA !== effortB) return effortA - effortB;
+    } else if (filter === "due-date") {
+      const dueA = getTaskDueSortTimestamp(a?.dueDate);
+      const dueB = getTaskDueSortTimestamp(b?.dueDate);
+      if (dueA !== dueB) return dueA - dueB;
+    }
 
-        const aCreated = new Date(a?.createdAt || 0).getTime();
-        const bCreated = new Date(b?.createdAt || 0).getTime();
-        return bCreated - aCreated;
-    });
+    const aCreated = new Date(a?.createdAt || 0).getTime();
+    const bCreated = new Date(b?.createdAt || 0).getTime();
+    return bCreated - aCreated;
+  });
 }
 
 function updateDashboardTaskFilterTabs(selectedFilter) {
-    const tabButtons = document.querySelectorAll(".task-list-tab");
-    if (!tabButtons.length) return;
+  const tabButtons = document.querySelectorAll(".task-list-tab");
+  if (!tabButtons.length) return;
 
-    tabButtons.forEach((buttonEl) => {
-        const isActive = buttonEl.dataset.filter === selectedFilter;
-        buttonEl.classList.toggle("is-active", isActive);
-        buttonEl.setAttribute("aria-selected", isActive ? "true" : "false");
-    });
+  tabButtons.forEach((buttonEl) => {
+    const isActive = buttonEl.dataset.filter === selectedFilter;
+    buttonEl.classList.toggle("is-active", isActive);
+    buttonEl.setAttribute("aria-selected", isActive ? "true" : "false");
+  });
 }
 
 function bindDashboardTaskFilterTabs() {
-    const tabButtons = document.querySelectorAll(".task-list-tab");
-    if (!tabButtons.length) return;
+  const tabButtons = document.querySelectorAll(".task-list-tab");
+  if (!tabButtons.length) return;
 
-    tabButtons.forEach((buttonEl) => {
-        buttonEl.addEventListener("click", () => {
-            const filter = buttonEl.dataset.filter || "task-list";
-            if (filter === dashboardTaskState.filter) return;
+  tabButtons.forEach((buttonEl) => {
+    buttonEl.addEventListener("click", () => {
+      const filter = buttonEl.dataset.filter || "task-list";
+      if (filter === dashboardTaskState.filter) return;
 
-            dashboardTaskState.filter = filter;
-            updateTaskList(dashboardTaskState.allTasks);
-        });
+      dashboardTaskState.filter = filter;
+      updateTaskList(dashboardTaskState.allTasks);
     });
+  });
 
-    updateDashboardTaskFilterTabs(dashboardTaskState.filter);
+  updateDashboardTaskFilterTabs(dashboardTaskState.filter);
 }
 
 // Function to update the UI with fetched tasks
 function updateTaskList(tasks) {
-    const listOfTasks = document.querySelector(".task-list");
-    const taskTemplate = document.querySelector("#task-template");
-    const bigThreeInteractions = new Map();
-    tasks = Array.isArray(tasks) ? tasks : [];
-    dashboardTaskState.allTasks = tasks;
+  const listOfTasks = document.querySelector(".task-list");
+  const taskTemplate = document.querySelector("#task-template");
+  const bigThreeInteractions = new Map();
+  tasks = Array.isArray(tasks) ? tasks : [];
+  dashboardTaskState.allTasks = tasks;
 
-    const baseSortedTasks = getDashboardTasksByFilter(tasks, "task-list");
-    const sortedTasks = getDashboardTasksByFilter(tasks, dashboardTaskState.filter);
+  const baseSortedTasks = getDashboardTasksByFilter(tasks, "task-list");
+  const sortedTasks = getDashboardTasksByFilter(
+    tasks,
+    dashboardTaskState.filter,
+  );
 
-    if (!listOfTasks) {
-        return; // Avoid errors on pages without the dashboard
+  if (!listOfTasks) {
+    return; // Avoid errors on pages without the dashboard
+  }
+  if (!taskTemplate) {
+    console.error("Task template not found in DOM");
+    return;
+  }
+
+  listOfTasks.innerHTML = ""; // Clear existing task list
+
+  sortedTasks.forEach((task) => {
+    const clone = taskTemplate.content.cloneNode(true);
+    const taskItem = clone.querySelector(".task-item");
+    const taskText = clone.querySelector(".task-text");
+    const taskDetailsTrigger = clone.querySelector(".task-details-trigger");
+    const taskCheck = clone.querySelector(".task-check");
+    const dueText = clone.querySelector(".task-due");
+    const effortDots = clone.querySelectorAll(".task-effort .dot");
+    const bigThreeIndicator = clone.querySelector(".task-big-three-indicator");
+    const bigThreeButton = clone.querySelector(".big-three-btn");
+    const panelBigThreeButton = document.getElementById("panelBigThreeBtn");
+
+    if (taskItem && taskText) {
+      taskText.textContent = task.description;
+      taskText.title = "Open task details";
     }
-    if (!taskTemplate) {
-        console.error("Task template not found in DOM");
+    const setTaskCompletion = async (isCompleted) => {
+      const updated = await updateTaskCompletionStatus(
+        task,
+        isCompleted,
+        taskCheck,
+        taskItem,
+        {
+          bigThreeButton,
+          panelBigThreeButton,
+        },
+      );
+
+      if (updated && activeTaskInPanel) {
+        activeTaskInPanel.syncCompletion(task.status);
+        activeTaskInPanel.syncBigThree(Boolean(task.isBigThree));
+      }
+
+      return updated;
+    };
+
+    if (taskCheck) {
+      taskCheck.checked = task.status === "completed";
+      taskItem?.classList.toggle("is-completed", taskCheck.checked);
+
+      taskCheck.addEventListener("change", async () => {
+        const isCompleted = taskCheck.checked;
+        const updated = await setTaskCompletion(isCompleted);
+
+        if (!updated) {
+          taskCheck.checked = !isCompleted;
+          taskItem?.classList.toggle("is-completed", taskCheck.checked);
+        }
+
+        // If the task was just completed and it's currently focused, end the focus session since the task is no longer active
+        if (
+          updated &&
+          isCompleted &&
+          focusState.taskId &&
+          String(focusState.taskId) === String(task._id)
+        ) {
+          await stopFocusSession("completed_task");
+        }
+      });
+    }
+
+    if (dueText) {
+      if (task.dueDate) {
+        dueText.textContent = formatTaskDueDate(task.dueDate);
+        dueText.hidden = false;
+      } else {
+        dueText.textContent = "";
+        dueText.hidden = true;
+      }
+    }
+    if (effortDots.length > 0) {
+      const effortLevel = Math.max(
+        1,
+        Math.min(5, parseInt(task.effortLevel, 10) || 3),
+      );
+      effortDots.forEach((dot, index) => {
+        dot.classList.toggle("on", index < effortLevel);
+      });
+    }
+    if (bigThreeIndicator) {
+      bigThreeIndicator.hidden = !task.isBigThree;
+      bigThreeIndicator.title = task.isBigThree ? "In Big 3" : "";
+    }
+    setBigThreeButtonState(bigThreeButton, task.isBigThree);
+
+    const toggleBigThree = async () => {
+      if (task.status === "completed") {
+        Toast.show({
+          message: "Completed tasks can't be added to Big 3.",
+          type: "error",
+          duration: 3200,
+        });
         return;
+      }
+
+      const nextIsBigThree = !task.isBigThree;
+      if (bigThreeButton) bigThreeButton.disabled = true;
+
+      try {
+        const updateResponse = await fetch(`/tasks/${task._id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isBigThree: nextIsBigThree }),
+        });
+
+        const updatedTask = await parseApiResponse(updateResponse);
+        if (updateResponse.ok) {
+          task.isBigThree = Boolean(updatedTask.isBigThree);
+          setBigThreeButtonState(bigThreeButton, task.isBigThree);
+          if (task.isBigThree) {
+            Toast.show({
+              message: "Task added to your Big 3",
+              type: "success",
+              duration: 2200,
+            });
+          }
+          fetchTasks();
+        } else {
+          Toast.show({
+            message: updatedTask.error || "Could not update Big 3 status.",
+            type: "error",
+            duration: 3500,
+          });
+          setBigThreeButtonState(bigThreeButton, task.isBigThree);
+        }
+      } catch (error) {
+        console.error("Task Big 3 toggle failed:", error);
+        Toast.show({
+          message: "Could not update Big 3 status.",
+          type: "error",
+          duration: 3000,
+        });
+        setBigThreeButtonState(bigThreeButton, task.isBigThree);
+      } finally {
+        if (bigThreeButton) bigThreeButton.disabled = false;
+      }
+    };
+
+    bigThreeButton?.addEventListener("click", toggleBigThree);
+
+    const saveTaskEdits = async (updates) => {
+      const updateResponse = await fetch(`/tasks/${task._id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updates),
+      });
+
+      const updateData = await parseApiResponse(updateResponse);
+      if (updateResponse.ok) {
+        Toast.show({
+          message: "Task Updated",
+          type: "success",
+          duration: 2000,
+        });
+        fetchTasks();
+        return updateData;
+      }
+
+      Toast.show({
+        message: updateData.error || "Error updating task",
+        type: "error",
+        duration: 3200,
+      });
+      return null;
+    };
+
+    // Add event listener for deleting a task
+    const deleteTask = async () => {
+      const confirmDelete = confirm(
+        "Are you sure you want to delete this task?",
+      );
+      if (confirmDelete) {
+        const deleteResponse = await fetch(`/tasks/${task._id}`, {
+          method: "DELETE",
+        });
+
+        if (deleteResponse.ok) {
+          console.log("Task deleted successfully");
+          Toast.show({
+            message: "Task deleted",
+            type: "success",
+            duration: 2000,
+          });
+          fetchTasks(); // Refresh task list after deletion
+        } else {
+          console.error("Error deleting task");
+        }
+      }
+    };
+
+    const rowDeleteButton = clone.querySelector(".delete-btn");
+
+    rowDeleteButton?.addEventListener("click", deleteTask);
+
+    const openTaskDetails = () => {
+      openTaskDetailPanel(task, {
+        toggleBigThree: async () => {
+          panelBigThreeButton.disabled = true;
+          await toggleBigThree();
+          if (activeTaskInPanel) {
+            activeTaskInPanel.syncBigThree(Boolean(task.isBigThree));
+          }
+          panelBigThreeButton.disabled = false;
+        },
+        saveTaskEdits,
+        deleteTask: async () => {
+          await deleteTask();
+          closeTaskDetailPanel();
+        },
+        toggleComplete: async () => {
+          const panelTaskComplete =
+            document.getElementById("panelTaskComplete");
+          if (!panelTaskComplete) return;
+
+          panelTaskComplete.disabled = true;
+          const isCompleted = panelTaskComplete.checked;
+          const updated = await setTaskCompletion(isCompleted);
+
+          if (!updated) {
+            panelTaskComplete.checked = !isCompleted;
+          }
+
+          panelTaskComplete.disabled = false;
+        },
+      });
+    };
+
+    taskDetailsTrigger?.addEventListener("click", openTaskDetails);
+    if (task?._id) {
+      bigThreeInteractions.set(task._id, {
+        openTaskDetails,
+        toggleComplete: setTaskCompletion,
+      });
     }
 
-    listOfTasks.innerHTML = ""; // Clear existing task list
+    listOfTasks.appendChild(clone);
+  });
 
-    sortedTasks.forEach((task) => {
-        const clone = taskTemplate.content.cloneNode(true);
-        const taskItem = clone.querySelector(".task-item");
-        const taskText = clone.querySelector(".task-text");
-        const taskDetailsTrigger = clone.querySelector(".task-details-trigger");
-        const taskCheck = clone.querySelector(".task-check");
-        const dueText = clone.querySelector(".task-due");
-        const effortDots = clone.querySelectorAll(".task-effort .dot");
-        const bigThreeIndicator = clone.querySelector(".task-big-three-indicator");
-        const bigThreeButton = clone.querySelector(".big-three-btn");
-        const panelBigThreeButton = document.getElementById("panelBigThreeBtn");
+  updateFocusTaskOptions(baseSortedTasks);
+  updateBigThreeWidget(baseSortedTasks, bigThreeInteractions);
 
-        if (taskItem && taskText) {
-            taskText.textContent = task.description;
-            taskText.title = "Open task details";
-        }
-        const setTaskCompletion = async (isCompleted) => {
-            const updated = await updateTaskCompletionStatus(task, isCompleted, taskCheck, taskItem, {
-                bigThreeButton,
-                panelBigThreeButton
-            });
-
-            if (updated && activeTaskInPanel) {
-                activeTaskInPanel.syncCompletion(task.status);
-                activeTaskInPanel.syncBigThree(Boolean(task.isBigThree));
-            }
-
-            return updated;
-        };
-
-        if (taskCheck) {
-            taskCheck.checked = task.status === "completed";
-            taskItem?.classList.toggle("is-completed", taskCheck.checked);
-
-            taskCheck.addEventListener("change", async () => {
-                const isCompleted = taskCheck.checked;
-                const updated = await setTaskCompletion(isCompleted);
-
-                if (!updated) {
-                    taskCheck.checked = !isCompleted;
-                    taskItem?.classList.toggle("is-completed", taskCheck.checked);
-                }
-
-                // If the task was just completed and it's currently focused, end the focus session since the task is no longer active
-                if (updated && isCompleted && focusState.taskId && String(focusState.taskId) === String(task._id)) {
-                    await stopFocusSession("completed_task");
-                }
-            });
-        }
-
-
-        if (dueText) {
-            if (task.dueDate) {
-                dueText.textContent = formatTaskDueDate(task.dueDate);
-                dueText.hidden = false;
-            } else {
-                dueText.textContent = "";
-                dueText.hidden = true;
-            }
-        }
-        if (effortDots.length > 0) {
-            const effortLevel = Math.max(1, Math.min(5, parseInt(task.effortLevel, 10) || 3));
-            effortDots.forEach((dot, index) => {
-                dot.classList.toggle("on", index < effortLevel);
-            });
-        }
-        if (bigThreeIndicator) {
-            bigThreeIndicator.hidden = !task.isBigThree;
-            bigThreeIndicator.title = task.isBigThree ? "In Big 3" : "";
-        }
-        setBigThreeButtonState(bigThreeButton, task.isBigThree);
-
-        const toggleBigThree = async () => {
-            if (task.status === "completed") {
-                Toast.show({ message: "Completed tasks can't be added to Big 3.", type: "error", duration: 3200 });
-                return;
-            }
-
-            const nextIsBigThree = !task.isBigThree;
-            if (bigThreeButton) bigThreeButton.disabled = true;
-
-            try {
-                const updateResponse = await fetch(`/tasks/${task._id}`, {
-                    method: "PUT",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ isBigThree: nextIsBigThree })
-                });
-
-                const updatedTask = await parseApiResponse(updateResponse);
-                if (updateResponse.ok) {
-                    task.isBigThree = Boolean(updatedTask.isBigThree);
-                    setBigThreeButtonState(bigThreeButton, task.isBigThree);
-                    if (task.isBigThree) {
-                        Toast.show({ message: "Task added to your Big 3", type: "success", duration: 2200 });
-                    }
-                    fetchTasks();
-                } else {
-                    Toast.show({ message: updatedTask.error || "Could not update Big 3 status.", type: "error", duration: 3500 });
-                    setBigThreeButtonState(bigThreeButton, task.isBigThree);
-                }
-            } catch (error) {
-                console.error("Task Big 3 toggle failed:", error);
-                Toast.show({ message: "Could not update Big 3 status.", type: "error", duration: 3000 });
-                setBigThreeButtonState(bigThreeButton, task.isBigThree);
-            } finally {
-                if (bigThreeButton) bigThreeButton.disabled = false;
-            }
-        };
-
-        bigThreeButton?.addEventListener("click", toggleBigThree);
-
-        const saveTaskEdits = async (updates) => {
-            const updateResponse = await fetch(`/tasks/${task._id}`, {
-                method: "PUT",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(updates)
-            });
-
-            const updateData = await parseApiResponse(updateResponse);
-            if (updateResponse.ok) {
-                Toast.show({ message: "Task Updated", type: "success", duration: 2000 });
-                fetchTasks();
-                return updateData;
-            }
-
-            Toast.show({ message: updateData.error || "Error updating task", type: "error", duration: 3200 });
-            return null;
-        };
-
-        // Add event listener for deleting a task
-        const deleteTask = async () => {
-            const confirmDelete = confirm("Are you sure you want to delete this task?");
-            if (confirmDelete) {
-                const deleteResponse = await fetch(`/tasks/${task._id}`, {
-                    method: "DELETE"
-                });
-
-                if (deleteResponse.ok) {
-                    console.log("Task deleted successfully");
-                    Toast.show({ message: "Task deleted", type: "success", duration: 2000 });
-                    fetchTasks(); // Refresh task list after deletion
-                } else {
-                    console.error("Error deleting task");
-                }
-            }
-        };
-
-        const rowDeleteButton = clone.querySelector(".delete-btn");
-
-        rowDeleteButton?.addEventListener("click", deleteTask);
-
-        const openTaskDetails = () => {
-            openTaskDetailPanel(task, {
-                toggleBigThree: async () => {
-                    panelBigThreeButton.disabled = true;
-                    await toggleBigThree();
-                    if (activeTaskInPanel) {
-                        activeTaskInPanel.syncBigThree(Boolean(task.isBigThree));
-                    }
-                    panelBigThreeButton.disabled = false;
-                },
-                saveTaskEdits,
-                deleteTask: async () => {
-                    await deleteTask();
-                    closeTaskDetailPanel();
-                },
-                toggleComplete: async () => {
-                    const panelTaskComplete = document.getElementById("panelTaskComplete");
-                    if (!panelTaskComplete) return;
-
-                    panelTaskComplete.disabled = true;
-                    const isCompleted = panelTaskComplete.checked;
-                    const updated = await setTaskCompletion(isCompleted);
-
-                    if (!updated) {
-                        panelTaskComplete.checked = !isCompleted;
-                    }
-
-                    panelTaskComplete.disabled = false;
-                }
-            });
-        };
-
-        taskDetailsTrigger?.addEventListener("click", openTaskDetails);
-        if (task?._id) {
-            bigThreeInteractions.set(task._id, {
-                openTaskDetails,
-                toggleComplete: setTaskCompletion
-            });
-        }
-
-        listOfTasks.appendChild(clone);
-    });
-
-    updateFocusTaskOptions(baseSortedTasks);
-    updateBigThreeWidget(baseSortedTasks, bigThreeInteractions);
-
-    // Update the task counter
-    document.querySelectorAll(".item-counter").forEach((el) => {
+  // Update the task counter
+  document.querySelectorAll(".item-counter").forEach((el) => {
     const activeCount = Array.isArray(tasks)
-        ? tasks.filter(t => t.status === "active").length
-        : 0;
+      ? tasks.filter((t) => t.status === "active").length
+      : 0;
 
     el.textContent = String(activeCount);
-    });
+  });
 
-    updateDashboardTaskFilterTabs(dashboardTaskState.filter);
+  updateDashboardTaskFilterTabs(dashboardTaskState.filter);
 
-    const clearCompletedButton = document.getElementById("clear-completed-tasks-btn");
-    if (clearCompletedButton) {
-        const hasCompletedTasks = Array.isArray(tasks) && tasks.some((task) => task.status === "completed");
-        clearCompletedButton.disabled = !hasCompletedTasks;
-    }
+  const clearCompletedButton = document.getElementById(
+    "clear-completed-tasks-btn",
+  );
+  if (clearCompletedButton) {
+    const hasCompletedTasks =
+      Array.isArray(tasks) && tasks.some((task) => task.status === "completed");
+    clearCompletedButton.disabled = !hasCompletedTasks;
+  }
 
-    // If no tasks, show a friendly message
-    if (sortedTasks.length === 0) {
-        listOfTasks.innerHTML = "<p>No tasks found. Add a new task to get started!</p>";
-    }
+  // If no tasks, show a friendly message
+  if (sortedTasks.length === 0) {
+    listOfTasks.innerHTML =
+      "<p>No tasks found. Add a new task to get started!</p>";
+  }
 }
 
 // Only enable periodic refresh on pages that actually have the dashboard
@@ -1762,7 +2187,7 @@ if (hasDashboard) {
   const REFRESH_MS = 30000;
 
   function refreshDashboard() {
-    checkAuthStatus( );
+    checkAuthStatus();
   }
 
   setInterval(refreshDashboard, REFRESH_MS);
@@ -1774,12 +2199,6 @@ if (hasDashboard) {
   });
 }
 
-
-
-
-
-
-
 // ----------------------------
 // Responsive Nav (drawer + view select)
 // ----------------------------
@@ -1787,7 +2206,9 @@ document.addEventListener("DOMContentLoaded", () => {
   const toggle = document.querySelector(".nav__toggle");
   const drawer = document.getElementById("nav-drawer");
   const backdrop = document.getElementById("nav-backdrop");
-  const compactNav = window.matchMedia("(max-width: 1023px), (hover: none) and (pointer: coarse)");
+  const compactNav = window.matchMedia(
+    "(max-width: 1023px), (hover: none) and (pointer: coarse)",
+  );
 
   if (toggle && drawer && backdrop) {
     const openDrawer = () => {
@@ -1814,7 +2235,8 @@ document.addEventListener("DOMContentLoaded", () => {
     backdrop.addEventListener("click", closeDrawer);
 
     document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape" && drawer.classList.contains("is-open")) closeDrawer();
+      if (e.key === "Escape" && drawer.classList.contains("is-open"))
+        closeDrawer();
     });
 
     drawer.querySelectorAll("a").forEach((a) => {
@@ -1833,8 +2255,12 @@ document.addEventListener("DOMContentLoaded", () => {
 // Mobile/tablet sticky-note center activation
 // ----------------------------
 document.addEventListener("DOMContentLoaded", () => {
-  const compactView = window.matchMedia("(max-width: 1023px), (hover: none) and (pointer: coarse)");
-  const stickyNotes = Array.from(document.querySelectorAll(".corkboard .sticky-note"));
+  const compactView = window.matchMedia(
+    "(max-width: 1023px), (hover: none) and (pointer: coarse)",
+  );
+  const stickyNotes = Array.from(
+    document.querySelectorAll(".corkboard .sticky-note"),
+  );
   if (stickyNotes.length === 0) return;
 
   let rafId = null;
@@ -1851,7 +2277,8 @@ document.addEventListener("DOMContentLoaded", () => {
       return;
     }
 
-    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    const viewportHeight =
+      window.innerHeight || document.documentElement.clientHeight;
     const centerY = viewportHeight * 0.5;
     const activeHalfBand = viewportHeight * 0.18; // ~36% total active zone around center
     const upperBound = centerY - activeHalfBand;

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>Stick A Pin</title>
@@ -7,7 +7,11 @@
     <script src="js/notification.js" defer></script>
     <script src="js/main.js" defer></script>
     <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/assets/image/donezo-logo.png"
+    />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
@@ -20,19 +24,21 @@
       href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-        <link
+    <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
     />
   </head>
   <body>
-    <header class="hero-header">
-      <h1>Stick A Pin</h1>
-    </header>
-
     <nav class="navbar">
       <div class="nav-left">
-        <button class="nav__toggle" type="button" aria-label="Open menu" aria-controls="nav-drawer" aria-expanded="false">
+        <button
+          class="nav__toggle"
+          type="button"
+          aria-label="Open menu"
+          aria-controls="nav-drawer"
+          aria-expanded="false"
+        >
           <i class="fa-solid fa-bars" aria-hidden="true"></i>
           <span class="sr-only">Menu</span>
         </button>
@@ -40,7 +46,7 @@
         <div class="logo-container">
           <div class="logo-sticky">
             <div class="thumbtack">
-              <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+              <i class="fa-solid fa-thumbtack" style="color: #c6534e"></i>
             </div>
           </div>
           <span class="brand-name">Stick A Pin</span>
@@ -52,7 +58,9 @@
         <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
         <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
         <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-        <li><a href="/profile-page.html" class="nav-item active">Profile</a></li>
+        <li>
+          <a href="/profile-page.html" class="nav-item active">Profile</a>
+        </li>
         <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
 
@@ -68,23 +76,46 @@
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>
 
-    <main class="corkboard" style="max-width: 1100px; margin: 2rem auto;">
-      <section class="sticky-note thumbtack" style="padding: 1.25rem;">
+    <main
+      class="corkboard placeholder-board"
+      style="max-width: 1100px; margin: 0 auto"
+    >
+      <section
+        class="sticky-note orange caution-tape page-placeholder"
+        aria-label="Profile page coming soon"
+      >
         <h2 class="widget-title">
-          <i class="fa-solid fa-user" style="color: #c6534e;"></i>
+          <i class="fa-solid fa-user" style="color: #c6534e"></i>
           Profile
         </h2>
-        <p>Your profile details will appear here.</p>
+        <p>
+          This page is currently in progress. Check back soon for profile tools
+          and details.
+        </p>
       </section>
     </main>
 
-    <div id="toast" class="toast toast--default" role="status" aria-live="polite" aria-atomic="true" hidden>
+    <div
+      id="toast"
+      class="toast toast--default"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      hidden
+    >
       <div class="toast__icon" aria-hidden="true">i</div>
       <div class="toast__content">
         <div id="toastTitle" class="toast__title" hidden></div>
         <div id="toastMessage" class="toast__message"></div>
       </div>
-      <button id="toastClose" class="toast__close" type="button" aria-label="Close notification">×</button>
+      <button
+        id="toastClose"
+        class="toast__close"
+        type="button"
+        aria-label="Close notification"
+      >
+        ×
+      </button>
       <div class="toast__progress"></div>
     </div>
   </body>

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>Stick A Pin</title>
@@ -7,7 +7,11 @@
     <script src="js/notification.js" defer></script>
     <script src="js/main.js" defer></script>
     <link rel="icon" type="image/png" href="/assets/image/donezo-logo.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/image/donezo-logo.png" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/assets/image/donezo-logo.png"
+    />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#f5ecd7" />
     <link rel="stylesheet" href="css/main.css" />
@@ -20,7 +24,7 @@
       href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Itim&family=Quantico:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
-        <link
+    <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
     />
@@ -28,14 +32,20 @@
   <body>
     <nav class="navbar">
       <div class="nav-left">
-        <button class="nav__toggle" type="button" aria-label="Open menu" aria-controls="nav-drawer" aria-expanded="false">
+        <button
+          class="nav__toggle"
+          type="button"
+          aria-label="Open menu"
+          aria-controls="nav-drawer"
+          aria-expanded="false"
+        >
           <i class="fa-solid fa-bars" aria-hidden="true"></i>
           <span class="sr-only">Menu</span>
         </button>
         <div class="logo-container">
           <div class="logo-sticky">
             <div class="thumbtack">
-              <i class="fa-solid fa-thumbtack" style="color:#c6534e;"></i>
+              <i class="fa-solid fa-thumbtack" style="color: #c6534e"></i>
             </div>
           </div>
           <span class="brand-name">Stick A Pin</span>
@@ -45,7 +55,9 @@
         <li><a href="/dashboard.html" class="nav-item">Board</a></li>
         <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
         <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
-        <li><a href="/settings-page.html" class="nav-item active">Settings</a></li>
+        <li>
+          <a href="/settings-page.html" class="nav-item active">Settings</a>
+        </li>
         <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
         <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
@@ -61,23 +73,46 @@
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>
 
-    <main class="corkboard" style="max-width: 1100px; margin: 2rem auto;">
-      <section class="sticky-note blue thumbtack" style="padding: 1.25rem;">
-        <h1 class="widget-title">
-          <i class="fa-solid fa-gear" style="color: #c6534e;"></i>
+    <main
+      class="corkboard placeholder-board"
+      style="max-width: 1100px; margin: 0 auto"
+    >
+      <section
+        class="sticky-note orange caution-tape page-placeholder"
+        aria-label="Settings page coming soon"
+      >
+        <h2 class="widget-title">
+          <i class="fa-solid fa-gear" style="color: #c6534e"></i>
           Settings
-        </h1>
-        <p>Settings options will appear here. This page now uses the same app styling and responsive nav.</p>
+        </h2>
+        <p>
+          This page is currently in progress. Check back soon for your settings
+          controls.
+        </p>
       </section>
     </main>
 
-    <div id="toast" class="toast toast--default" role="status" aria-live="polite" aria-atomic="true" hidden>
+    <div
+      id="toast"
+      class="toast toast--default"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      hidden
+    >
       <div class="toast__icon" aria-hidden="true">i</div>
       <div class="toast__content">
         <div id="toastTitle" class="toast__title" hidden></div>
         <div id="toastMessage" class="toast__message"></div>
       </div>
-      <button id="toastClose" class="toast__close" type="button" aria-label="Close notification">×</button>
+      <button
+        id="toastClose"
+        class="toast__close"
+        type="button"
+        aria-label="Close notification"
+      >
+        ×
+      </button>
       <div class="toast__progress"></div>
     </div>
   </body>


### PR DESCRIPTION
### Motivation
- Improve the focus mode experience with friendly, timed nudges and a typewriter quote UI to help users stay on task.
- Make unreleased pages (Calendar, Feedback, Profile, Settings) show consistent in-app placeholders until full implementations are ready.
- Clean up and standardize UI/CSS and JS for better accessibility, robustness, and maintainability (fewer duplicate DOM handlers, defensive checks).

### Description
- Implemented a focus quote system and session nudges in `public/js/main.js`, including `focusQuotes`, `setFocusQuoteText`, `scheduleSessionNudges`, improved start/stop session flows, `completeTask`, and safer timer/timeout cleanup in `focusState`.
- Consolidated and reorganized DOM load handling in `public/js/main.js` to centralize auth, registration, login, password reset, verification resend, task submission, nav behavior, and focus-mode initialization; also refactored task rendering logic via `updateTaskList`, `getDashboardTasksByFilter`, and improved task/panel interactions (Big 3 toggles, edit/save, delete, complete flows).
- Added a typewriter caret animation and related styles to `public/css/focus-page.css` and expanded `stickies.css` with normalized formatting, new `.placeholder-board` and `.page-placeholder` styles, a `.caution-tape` modifier, color normalization, and various spacing/formatting fixes.
- Updated multiple page templates (`calendar-page.html`, `feedback-page.html`, `profile-page.html`, `settings-page.html`) to use consistent `<!doctype html>`, tidy markup, standardized nav markup/ARIA, consistent toast button markup, and replaced unfinished pages with centered placeholder sticky notes with `aria-label` for accessibility.
- Miscellaneous defensive and stylistic JS changes: robust JSON parsing via `parseApiResponse`, safer date handling, improved null checks, and consolidated repeated CSS/HTML tweaks (icon color formatting, anchor list item formatting).

### Testing
- No automated tests were executed for this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2fbbb29288326abd6f9711dd18b89)