### PR TITLE
Add daily reflection email settings UI, backend APIs, and test-send feature

### DIFF
--- a/config/models/user.js
+++ b/config/models/user.js
@@ -28,6 +28,7 @@ const UserSchema = new mongoose.Schema(
     settings: {
       rememberMe: { type: Boolean, default: false },
       dailyEmail: { type: Boolean, default: true },
+      dailyEmailTime: { type: String, default: "18:00" },
       weeklyEmail: { type: Boolean, default: true },
       timezone: { type: String, default: "America/Jamaica" },
     },

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1782,3 +1782,96 @@ body.task-panel-open {
 .task-detail-effort-options[hidden] {
   display: none !important;
 }
+
+.settings-panel {
+  width: min(920px, 96%);
+}
+
+.daily-email-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.daily-email-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: "Itim", cursive;
+  font-size: 1.1rem;
+}
+
+.daily-email-label,
+.daily-email-time-label {
+  font-weight: 700;
+}
+
+#dailyEmailTime {
+  border: 2px solid #c6534e;
+  border-radius: 8px;
+  padding: 0.35rem 0.45rem;
+  font-family: "Quantico", sans-serif;
+  background: #fff7ee;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-flex;
+  width: 52px;
+  height: 30px;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: #d0d0d0;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.toggle-slider::before {
+  content: "";
+  position: absolute;
+  left: 4px;
+  bottom: 4px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.toggle-switch input:checked + .toggle-slider {
+  background: #54c67a;
+}
+
+.toggle-switch input:checked + .toggle-slider::before {
+  transform: translateX(22px);
+}
+
+#dailyEmailTestBtn {
+  align-self: flex-start;
+  border: 2px solid #c6534e;
+  border-radius: 10px;
+  padding: 0.4rem 1rem;
+  background: #ffe6d9;
+  color: #612a27;
+  font-family: "Quantico", sans-serif;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+#dailyEmailTestBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1868,8 +1868,9 @@ body.task-panel-open {
 
 .daily-reflection-title {
   margin: 0;
-  font-family: "Gochi Hand", cursive;
-  font-size: 1.4rem;
+  font-family: "Itim", cursive;
+  font-size: 1.1rem;
+  font-weight: 700;
   color: #3f2c20;
 }
 
@@ -1899,7 +1900,10 @@ body.task-panel-open {
 
 .daily-email-label,
 .daily-email-time-label {
-  font-weight: 700;
+  font-family: "Gochi Hand", cursive;
+  font-size: 1.4rem;
+  font-weight: 400;
+  color: #3f2c20;
 }
 
 #dailyEmailTime {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1871,7 +1871,7 @@ body.task-panel-open {
   font-family: "Itim", cursive;
   font-size: 1.1rem;
   font-weight: 700;
-  color: #3f2c20;
+  color: #c6534e;
 }
 
 .daily-email-settings {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1783,39 +1783,6 @@ body.task-panel-open {
   display: none !important;
 }
 
-.settings-panel {
-  width: min(920px, 96%);
-}
-
-.daily-email-settings {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  margin-top: 1rem;
-}
-
-.daily-email-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-  font-family: "Itim", cursive;
-  font-size: 1.1rem;
-}
-
-.daily-email-label,
-.daily-email-time-label {
-  font-weight: 700;
-}
-
-#dailyEmailTime {
-  border: 2px solid #c6534e;
-  border-radius: 8px;
-  padding: 0.35rem 0.45rem;
-  font-family: "Quantico", sans-serif;
-  background: #fff7ee;
-}
-
 .toggle-switch {
   position: relative;
   display: inline-flex;
@@ -1874,4 +1841,77 @@ body.task-panel-open {
 #dailyEmailTestBtn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+
+.corkboard.placeholder-board.settings-board {
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 2rem;
+}
+
+.settings-panel {
+  width: min(920px, 96%);
+}
+
+.daily-reflection-card {
+  margin-top: 1rem;
+  background: #fff;
+  border: 2px solid #f1e2ba;
+  border-radius: 6px 14px 8px 12px;
+  box-shadow:
+    0 3px 8px rgba(0, 0, 0, 0.18),
+    inset 0 -8px 10px rgba(0, 0, 0, 0.04);
+  padding: 1rem 1.1rem;
+  transform: rotate(-0.3deg);
+}
+
+.daily-reflection-title {
+  margin: 0;
+  font-family: "Gochi Hand", cursive;
+  font-size: 1.4rem;
+  color: #3f2c20;
+}
+
+.daily-email-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin-top: 0.9rem;
+}
+
+.daily-email-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: "Itim", cursive;
+  font-size: 1.1rem;
+}
+
+.daily-email-toggle-row {
+  justify-content: flex-start;
+}
+
+.daily-email-time-row {
+  padding-left: 0;
+}
+
+.daily-email-label,
+.daily-email-time-label {
+  font-weight: 700;
+}
+
+#dailyEmailTime {
+  border: 2px solid #c6534e;
+  border-radius: 8px;
+  padding: 0.35rem 0.45rem;
+  font-family: "Quantico", sans-serif;
+  background: #fff7ee;
+}
+
+@media (min-width: 768px) {
+  .daily-email-time-row {
+    padding-left: 0.15rem;
+  }
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -798,6 +798,112 @@ async function initFocusMode() {
   });
 }
 
+async function initDailyEmailSettings() {
+  const toggleEl = document.getElementById("dailyEmailToggle");
+  const timeEl = document.getElementById("dailyEmailTime");
+  const testBtn = document.getElementById("dailyEmailTestBtn");
+
+  if (!toggleEl || !timeEl || !testBtn) return;
+
+  const setInputsDisabled = (disabled) => {
+    toggleEl.disabled = disabled;
+    timeEl.disabled = disabled;
+    testBtn.disabled = disabled;
+  };
+
+  const saveSettings = async () => {
+    try {
+      const response = await fetch("/settings/daily-email", {
+        credentials: "include",
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dailyEmail: toggleEl.checked,
+          dailyEmailTime: timeEl.value || "18:00",
+        }),
+      });
+
+      const data = await parseApiResponse(response);
+      if (!response.ok) {
+        throw new Error(data?.error || "Unable to save daily email settings.");
+      }
+
+      Toast.show({
+        message: "Daily reflection settings saved",
+        type: "success",
+        duration: 1800,
+      });
+    } catch (error) {
+      console.error("Saving daily email settings failed:", error);
+      Toast.show({
+        message: error.message || "Could not save daily reflection settings.",
+        type: "error",
+        duration: 2600,
+      });
+    }
+  };
+
+  try {
+    setInputsDisabled(true);
+    const response = await fetch("/settings/daily-email", {
+      credentials: "include",
+      cache: "no-store",
+    });
+
+    const data = await parseApiResponse(response);
+    if (!response.ok) {
+      throw new Error(data?.error || "Unable to load daily email settings.");
+    }
+
+    toggleEl.checked = Boolean(data?.dailyEmail);
+    timeEl.value = typeof data?.dailyEmailTime === "string" ? data.dailyEmailTime : "18:00";
+  } catch (error) {
+    console.error("Loading daily email settings failed:", error);
+    Toast.show({
+      message: "Could not load daily reflection settings.",
+      type: "error",
+      duration: 2600,
+    });
+  } finally {
+    setInputsDisabled(false);
+  }
+
+  toggleEl.addEventListener("change", saveSettings);
+  timeEl.addEventListener("change", saveSettings);
+
+  testBtn.addEventListener("click", async () => {
+    testBtn.disabled = true;
+
+    try {
+      const response = await fetch("/settings/daily-email/test", {
+        credentials: "include",
+        method: "POST",
+      });
+
+      const data = await parseApiResponse(response);
+      if (!response.ok) {
+        throw new Error(data?.error || "Unable to send test email.");
+      }
+
+      Toast.show({
+        message: "Test daily reflection email sent",
+        type: "success",
+        duration: 2600,
+      });
+    } catch (error) {
+      console.error("Sending daily email test failed:", error);
+      Toast.show({
+        message: error.message || "Could not send test daily reflection email.",
+        type: "error",
+        duration: 3000,
+      });
+    } finally {
+      testBtn.disabled = false;
+    }
+  });
+}
+
+
 document.addEventListener("DOMContentLoaded", () => {
   console.log("DOM Fully Loaded - JavaScript Running");
 
@@ -1130,6 +1236,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   bindDashboardTaskFilterTabs();
+  initDailyEmailSettings();
 
   checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
   initFocusMode();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -872,6 +872,16 @@ async function initDailyEmailSettings() {
   timeEl.addEventListener("change", saveSettings);
 
   testBtn.addEventListener("click", async () => {
+    if (!toggleEl.checked) {
+      Toast.show({
+        message:
+          'Unable to send daily reflection. Turn on "Daily Reflection" in settings to receive daily reflection emails.',
+        type: "error",
+        duration: 3200,
+      });
+      return;
+    }
+
     testBtn.disabled = true;
 
     try {
@@ -882,7 +892,7 @@ async function initDailyEmailSettings() {
 
       const data = await parseApiResponse(response);
       if (!response.ok) {
-        throw new Error(data?.error || "Unable to send test email.");
+        throw new Error(data?.error || "Unable to send daily reflection. Turn on \"Daily Reflection\" in settings to receive daily reflection emails.");
       }
 
       Toast.show({

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -74,7 +74,7 @@
     <div id="nav-backdrop" aria-hidden="true"></div>
 
     <main
-      class="corkboard placeholder-board"
+      class="corkboard placeholder-board settings-board"
       style="max-width: 1100px; margin: 0 auto"
     >
       <section class="sticky-note orange caution-tape settings-panel">
@@ -82,22 +82,31 @@
           <i class="fa-solid fa-gear" style="color: #c6534e"></i>
           Settings
         </h2>
-        <div class="daily-email-settings">
-          <div class="daily-email-row">
-            <label for="dailyEmailToggle" class="daily-email-label"
-              >Receive Daily Reflection:</label
-            >
-            <label class="toggle-switch" for="dailyEmailToggle">
-              <input type="checkbox" id="dailyEmailToggle" />
-              <span class="toggle-slider" aria-hidden="true"></span>
-            </label>
-            <label for="dailyEmailTime" class="daily-email-time-label"
-              >Send Time:</label
-            >
-            <input type="time" id="dailyEmailTime" value="18:00" />
+
+        <section class="daily-reflection-card" aria-label="Daily reflection email settings">
+          <h3 class="daily-reflection-title">Daily Reflection:</h3>
+
+          <div class="daily-email-settings">
+            <div class="daily-email-row daily-email-toggle-row">
+              <label for="dailyEmailToggle" class="daily-email-label"
+                >Receive Daily Reflection:</label
+              >
+              <label class="toggle-switch" for="dailyEmailToggle">
+                <input type="checkbox" id="dailyEmailToggle" />
+                <span class="toggle-slider" aria-hidden="true"></span>
+              </label>
+            </div>
+
+            <div class="daily-email-row daily-email-time-row">
+              <label for="dailyEmailTime" class="daily-email-time-label"
+                >Send Time:</label
+              >
+              <input type="time" id="dailyEmailTime" value="18:00" />
+            </div>
+
+            <button id="dailyEmailTestBtn" class="btn" type="button">Test</button>
           </div>
-          <button id="dailyEmailTestBtn" class="btn" type="button">Test</button>
-        </div>
+        </section>
       </section>
     </main>
 

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -84,7 +84,7 @@
         </h2>
 
         <section class="daily-reflection-card" aria-label="Daily reflection email settings">
-          <h3 class="daily-reflection-title">Daily Reflection:</h3>
+          <h2 class="daily-reflection-title">Daily Reflection:</h2>
 
           <div class="daily-email-settings">
             <div class="daily-email-row daily-email-toggle-row">

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -77,18 +77,27 @@
       class="corkboard placeholder-board"
       style="max-width: 1100px; margin: 0 auto"
     >
-      <section
-        class="sticky-note orange caution-tape page-placeholder"
-        aria-label="Settings page coming soon"
-      >
+      <section class="sticky-note orange caution-tape settings-panel">
         <h2 class="widget-title">
           <i class="fa-solid fa-gear" style="color: #c6534e"></i>
           Settings
         </h2>
-        <p>
-          This page is currently in progress. Check back soon for your settings
-          controls.
-        </p>
+        <div class="daily-email-settings">
+          <div class="daily-email-row">
+            <label for="dailyEmailToggle" class="daily-email-label"
+              >Receive Daily Reflection:</label
+            >
+            <label class="toggle-switch" for="dailyEmailToggle">
+              <input type="checkbox" id="dailyEmailToggle" />
+              <span class="toggle-slider" aria-hidden="true"></span>
+            </label>
+            <label for="dailyEmailTime" class="daily-email-time-label"
+              >Send Time:</label
+            >
+            <input type="time" id="dailyEmailTime" value="18:00" />
+          </div>
+          <button id="dailyEmailTestBtn" class="btn" type="button">Test</button>
+        </div>
       </section>
     </main>
 

--- a/server.js
+++ b/server.js
@@ -140,6 +140,125 @@ function resolveBaseUrl(req) {
   return `http://localhost:${port}`;
 }
 
+
+function isValidTimeInput(value) {
+  return typeof value === "string" && /^([01]\d|2[0-3]):([0-5]\d)$/.test(value);
+}
+
+function formatDurationFromMs(durationMs) {
+  const safeDurationMs = Math.max(0, Number(durationMs) || 0);
+  const totalMinutes = Math.floor(safeDurationMs / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours === 0) {
+    return `${minutes}m`;
+  }
+
+  if (minutes === 0) {
+    return `${hours}h`;
+  }
+
+  return `${hours}h ${minutes}m`;
+}
+
+function escapeHtml(value) {
+  return String(value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function getTodayBounds() {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { start, end };
+}
+
+async function buildDailyReflectionEmailData(userId) {
+  const { start, end } = getTodayBounds();
+
+  const [completedToday, tasksCreatedToday, sessionsToday] = await Promise.all([
+    Task.find({
+      userId,
+      status: "completed",
+      completedAt: { $gte: start, $lt: end },
+    }).sort({ completedAt: 1 }),
+    Task.countDocuments({
+      userId,
+      createdAt: { $gte: start, $lt: end },
+    }),
+    FocusSession.find({
+      userId,
+      startedAt: { $gte: start, $lt: end },
+      durationMs: { $gt: 0 },
+    }).select("durationMs"),
+  ]);
+
+  const totalFocusMs = sessionsToday.reduce((sum, session) => sum + (Number(session.durationMs) || 0), 0);
+  const completionRate = tasksCreatedToday > 0
+    ? Math.round((completedToday.length / tasksCreatedToday) * 100)
+    : 0;
+
+  const completedTaskNames = completedToday.map((task) => {
+    const title = String(task.title || "").trim();
+    return title || String(task.description || "").trim() || "Untitled task";
+  });
+
+  return {
+    completedTaskNames,
+    totalFocusMs,
+    completionRate,
+    dateLabel: start.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" }),
+  };
+}
+
+async function sendDailyReflectionEmail(user, emailData) {
+  if (!process.env.RESEND_API_KEY) {
+    throw new Error("RESEND_API_KEY is not configured");
+  }
+
+  const taskListLabel = emailData.completedTaskNames.length > 0
+    ? emailData.completedTaskNames.join(", ")
+    : "No completed tasks";
+
+  const subject = `Daily Reflection — ${taskListLabel}`.slice(0, 220);
+
+  const tasksHtml = emailData.completedTaskNames.length > 0
+    ? `<ul>${emailData.completedTaskNames.map((taskName) => `<li>${escapeHtml(taskName)}</li>`).join("")}</ul>`
+    : "<p>No tasks were completed today.</p>";
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: EMAIL_FROM,
+      to: [user.email],
+      subject,
+      html: `
+        <p>Hi ${escapeHtml(user.firstName || "there")},</p>
+        <p>Here is your daily reflection for ${escapeHtml(emailData.dateLabel)}.</p>
+        <p><strong>Completed tasks:</strong></p>
+        ${tasksHtml}
+        <p><strong>Total focus time:</strong> ${escapeHtml(formatDurationFromMs(emailData.totalFocusMs))}</p>
+        <p><strong>Task completion rate:</strong> ${escapeHtml(String(emailData.completionRate))}%</p>
+      `,
+    }),
+  });
+
+  if (!response.ok) {
+    const failure = await response.text();
+    throw new Error(`Resend API request failed (${response.status}): ${failure}`);
+  }
+}
+
 // Session Handling
 app.set("trust proxy", 1); // important on Vercel / proxies
 
@@ -735,6 +854,75 @@ app.get("/focus-sessions", ensureAuthenticated, async (req, res) => {
 
 
 
+
+
+app.get("/settings/daily-email", ensureAuthenticated, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id).select("settings.dailyEmail settings.dailyEmailTime");
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    return res.json({
+      dailyEmail: user.settings?.dailyEmail !== false,
+      dailyEmailTime: isValidTimeInput(user.settings?.dailyEmailTime)
+        ? user.settings.dailyEmailTime
+        : "18:00",
+    });
+  } catch (error) {
+    console.error("Error loading daily email settings:", error);
+    return res.status(500).json({ error: "Unable to load daily email settings" });
+  }
+});
+
+app.put("/settings/daily-email", ensureAuthenticated, async (req, res) => {
+  try {
+    const dailyEmail = Boolean(req.body.dailyEmail);
+    const requestedTime = String(req.body.dailyEmailTime || "").trim();
+    const dailyEmailTime = isValidTimeInput(requestedTime) ? requestedTime : "18:00";
+
+    const updatedUser = await User.findByIdAndUpdate(
+      req.user.id,
+      {
+        $set: {
+          "settings.dailyEmail": dailyEmail,
+          "settings.dailyEmailTime": dailyEmailTime,
+        },
+      },
+      { new: true, runValidators: true }
+    ).select("settings.dailyEmail settings.dailyEmailTime");
+
+    if (!updatedUser) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    return res.json({
+      message: "Daily email settings updated",
+      dailyEmail: updatedUser.settings?.dailyEmail !== false,
+      dailyEmailTime: updatedUser.settings?.dailyEmailTime || "18:00",
+    });
+  } catch (error) {
+    console.error("Error saving daily email settings:", error);
+    return res.status(500).json({ error: "Unable to save daily email settings" });
+  }
+});
+
+app.post("/settings/daily-email/test", ensureAuthenticated, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id).select("email firstName");
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const emailData = await buildDailyReflectionEmailData(req.user.id);
+    await sendDailyReflectionEmail(user, emailData);
+
+    return res.json({ message: "Daily reflection test email sent" });
+  } catch (error) {
+    console.error("Error sending daily reflection test email:", error);
+    return res.status(500).json({ error: "Unable to send daily reflection test email" });
+  }
+});
 
 
 // Route to check user authentication status

--- a/server.js
+++ b/server.js
@@ -905,9 +905,15 @@ app.put("/settings/daily-email", ensureAuthenticated, async (req, res) => {
 
 app.post("/settings/daily-email/test", ensureAuthenticated, async (req, res) => {
   try {
-    const user = await User.findById(req.user.id).select("email firstName");
+    const user = await User.findById(req.user.id).select("email firstName settings.dailyEmail");
     if (!user) {
       return res.status(404).json({ error: "User not found" });
+    }
+
+    if (user.settings?.dailyEmail === false) {
+      return res.status(403).json({
+        error: 'Unable to send daily reflection. Turn on "Daily Reflection" in settings to receive daily reflection emails.',
+      });
     }
 
     const emailData = await buildDailyReflectionEmailData(req.user.id);

--- a/server.js
+++ b/server.js
@@ -222,11 +222,7 @@ async function sendDailyReflectionEmail(user, emailData) {
     throw new Error("RESEND_API_KEY is not configured");
   }
 
-  const taskListLabel = emailData.completedTaskNames.length > 0
-    ? emailData.completedTaskNames.join(", ")
-    : "No completed tasks";
-
-  const subject = `Daily Reflection — ${taskListLabel}`.slice(0, 220);
+  const subject = "Your Daily Reflection";
 
   const tasksHtml = emailData.completedTaskNames.length > 0
     ? `<ul>${emailData.completedTaskNames.map((taskName) => `<li>${escapeHtml(taskName)}</li>`).join("")}</ul>`


### PR DESCRIPTION
### Motivation
- Provide users a simple on/off control and send-time for the daily reflection email so they can opt into receiving a summary each day. 
- Allow users to immediately verify the email content with a `Test` button that sends the reflection to their email now. 
- Include the summary content (completed tasks, total focus time, completion rate) in the daily email subject/body for helpful daily insights.

### Description
- Added settings UI to `public/settings-page.html` including the label `Receive Daily Reflection:`, a custom on/off toggle, a `time` input and a `Test` button. 
- Added styles in `public/css/main.css` for `.settings-panel`, `.daily-email-settings`, the custom `.toggle-switch`, and `#dailyEmailTestBtn`. 
- Implemented client-side logic in `public/js/main.js` via `initDailyEmailSettings()` to load/save settings (`GET`/`PUT /settings/daily-email`) and trigger an immediate send (`POST /settings/daily-email/test`) with toast feedback. 
- Extended the `User` model (`config/models/user.js`) to persist `settings.dailyEmailTime` with default `"18:00"`. 
- Added server helpers and email builders in `server.js`: `isValidTimeInput`, `formatDurationFromMs`, `getTodayBounds`, `buildDailyReflectionEmailData`, and `sendDailyReflectionEmail`, and implemented API endpoints `GET /settings/daily-email`, `PUT /settings/daily-email`, and `POST /settings/daily-email/test`. 
- Email content: subject lists completed tasks for the day (truncated), body contains a task list, total focus time, and the day's task completion rate; emails are sent via the existing Resend API integration. 
- Note: scheduling a background dispatcher to send emails at the saved time is not included in this PR.

### Testing
- Performed static checks with `node --check server.js` and `node --check public/js/main.js`, both succeeded. 
- Attempted a headless browser screenshot to validate UI rendering, but Playwright navigation failed in this environment (`net::ERR_EMPTY_RESPONSE` / file access limitations). 
- Committed changes as: `Add daily reflection email controls and test send flow` (files modified include `public/settings-page.html`, `public/css/main.css`, `public/js/main.js`, `config/models/user.js`, and `server.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30d44bdb48326b576c44146d51d82)