### PR TITLE
Center focus status and add dashboard CTA for empty focus list

### DIFF
--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -59,6 +59,7 @@
   font-size: 0.95rem;
   line-height: 1.3;
   overflow-wrap: anywhere;
+  text-align: center;
 }
 
 .focus-session-center {
@@ -196,6 +197,13 @@
 
 .focus-task-empty {
   opacity: 0.8;
+  text-align: center;
+}
+
+.focus-task-empty-link {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 700;
 }
 
 .focus-task-list[aria-disabled="true"] .focus-task-option {

--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -59,7 +59,9 @@
   font-size: 0.95rem;
   line-height: 1.3;
   overflow-wrap: anywhere;
+  width: 100%;
   text-align: center;
+  align-self: center;
 }
 
 .focus-session-center {
@@ -198,6 +200,10 @@
 .focus-task-empty {
   opacity: 0.8;
   text-align: center;
+}
+
+.focus-task-empty > span {
+  display: inline;
 }
 
 .focus-task-empty-link {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1924,11 +1924,8 @@ body.task-panel-open {
 }
 
 .daily-reflection-today {
-  margin-top: 0.7rem;
-  border: 1px dashed rgba(198, 83, 78, 0.45);
-  border-radius: 10px;
-  padding: 0.65rem 0.75rem;
-  background: rgba(255, 247, 238, 0.7);
+  margin-top: 0.45rem;
+  padding: 0;
   font-family: "Gochi Hand", cursive;
   color: #3f2c20;
 }
@@ -1945,7 +1942,8 @@ body.task-panel-open {
   list-style: none;
   display: grid;
   gap: 0.12rem;
-  font-size: 1.25rem;
+  font-size: 1.02rem;
+  opacity: 0.82;
 }
 
 .daily-reflection-metrics li {
@@ -1955,11 +1953,11 @@ body.task-panel-open {
 }
 
 .daily-reflection-metric-label {
-  font-weight: 700;
+  font-weight: 400;
 }
 
 .daily-reflection-metric-value {
-  font-weight: 600;
+  font-weight: 400;
 }
 
 @media (min-width: 768px) {
@@ -1981,7 +1979,7 @@ body.task-panel-open {
   }
 
   .daily-reflection-today {
-    padding: 0.58rem 0.62rem;
+    padding: 0;
   }
 
   .daily-reflection-today-date {
@@ -1989,6 +1987,6 @@ body.task-panel-open {
   }
 
   .daily-reflection-metrics {
-    font-size: 1.12rem;
+    font-size: 0.98rem;
   }
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1908,14 +1908,19 @@ body.task-panel-open {
   color: #3f2c20;
 }
 
+.daily-email-time-label {
+  white-space: nowrap;
+}
+
 #dailyEmailTime {
   border: 2px solid #c6534e;
   border-radius: 8px;
   padding: 0.35rem 0.45rem;
   font-family: "Quantico", sans-serif;
   background: #fff7ee;
-  width: auto;
-  max-width: 10.5rem;
+  margin-left: 0;
+  flex: 0 0 auto;
+  width: clamp(7.75rem, 34vw, 10.5rem);
 }
 
 @media (min-width: 768px) {
@@ -1931,7 +1936,7 @@ body.task-panel-open {
   }
 
   #dailyEmailTime {
-    max-width: 9.75rem;
+    width: 8rem;
     min-width: 0;
   }
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1920,7 +1920,46 @@ body.task-panel-open {
   background: #fff7ee;
   margin-left: 0;
   flex: 0 0 auto;
-  width: clamp(7.75rem, 34vw, 10.5rem);
+  width: 8.5rem;
+}
+
+.daily-reflection-today {
+  margin-top: 0.7rem;
+  border: 1px dashed rgba(198, 83, 78, 0.45);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  background: rgba(255, 247, 238, 0.7);
+  font-family: "Gochi Hand", cursive;
+  color: #3f2c20;
+}
+
+.daily-reflection-today-date {
+  margin: 0 0 0.28rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.daily-reflection-metrics {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.12rem;
+  font-size: 1.25rem;
+}
+
+.daily-reflection-metrics li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.daily-reflection-metric-label {
+  font-weight: 700;
+}
+
+.daily-reflection-metric-value {
+  font-weight: 600;
 }
 
 @media (min-width: 768px) {
@@ -1936,7 +1975,20 @@ body.task-panel-open {
   }
 
   #dailyEmailTime {
-    width: 8rem;
+    width: 6.9rem;
     min-width: 0;
+    padding: 0.3rem 0.35rem;
+  }
+
+  .daily-reflection-today {
+    padding: 0.58rem 0.62rem;
+  }
+
+  .daily-reflection-today-date {
+    font-size: 1.25rem;
+  }
+
+  .daily-reflection-metrics {
+    font-size: 1.12rem;
   }
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1851,7 +1851,7 @@ body.task-panel-open {
 }
 
 .settings-panel {
-  width: min(920px, 96%);
+  width: min(860px, 94%);
 }
 
 .daily-reflection-card {
@@ -1896,6 +1896,8 @@ body.task-panel-open {
 
 .daily-email-time-row {
   padding-left: 0;
+  flex-wrap: nowrap;
+  align-items: center;
 }
 
 .daily-email-label,
@@ -1912,10 +1914,24 @@ body.task-panel-open {
   padding: 0.35rem 0.45rem;
   font-family: "Quantico", sans-serif;
   background: #fff7ee;
+  width: auto;
+  max-width: 10.5rem;
 }
 
 @media (min-width: 768px) {
   .daily-email-time-row {
     padding-left: 0.15rem;
+  }
+}
+
+
+@media (max-width: 767px) {
+  .daily-email-time-row {
+    gap: 0.45rem;
+  }
+
+  #dailyEmailTime {
+    max-width: 9.75rem;
+    min-width: 0;
   }
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -247,8 +247,25 @@
               <!-- Daily Reflection -->
               <div id="daily-reflection" class="sticky-note white tape">
                 <h3 class="widget-title highlight-on-parent-hover">
-                  Daily Relfection
+                  Daily Reflection
                 </h3>
+                <section class="daily-reflection-today" aria-live="polite" aria-label="Today's reflection stats">
+                  <p id="dailyReflectionDate" class="daily-reflection-today-date"></p>
+                  <ul class="daily-reflection-metrics" role="list">
+                    <li>
+                      <span class="daily-reflection-metric-label">Tasks focused on:</span>
+                      <span id="dailyReflectionTasksFocused" class="daily-reflection-metric-value">—</span>
+                    </li>
+                    <li>
+                      <span class="daily-reflection-metric-label">Task focus time:</span>
+                      <span id="dailyReflectionFocusTime" class="daily-reflection-metric-value">—</span>
+                    </li>
+                    <li>
+                      <span class="daily-reflection-metric-label">Task completion rate:</span>
+                      <span id="dailyReflectionCompletionRate" class="daily-reflection-metric-value">—</span>
+                    </li>
+                  </ul>
+                </section>
               </div>
               <!-- Weekly Reflection -->
               <div id="weekly-reflection" class="sticky-note white tape">

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -90,7 +90,7 @@
             <!-- Task List -->
             <div id="task-list-widget" class="sticky-note thumbtack task-note">
               <div class="task-list-header">
-                <h2 class="widget-title highlight-on-parent-hover">
+                <h2 class="widget-title">
                   <i class="fa-solid fa-list" style="color: #c6534e"></i>
                   Task List
                 </h2>
@@ -219,7 +219,7 @@
             <!-- Big 3 Tasks -->
             <div id="big-3-tasks" class="sticky-note pink thumbtack">
               <!-- Title -->
-              <h2 class="widget-title highlight-on-parent-hover">
+              <h2 class="widget-title">
                 <i class="fa-solid fa-star" style="color: #c6534e"></i>
                 Big 3 Tasks
               </h2>
@@ -246,7 +246,7 @@
             <div id="reflection-section">
               <!-- Daily Reflection -->
               <div id="daily-reflection" class="sticky-note white tape">
-                <h3 class="widget-title highlight-on-parent-hover">
+                <h3 class="widget-title">
                   Daily Reflection
                 </h3>
                 <section class="daily-reflection-today" aria-live="polite" aria-label="Today's reflection stats">
@@ -269,7 +269,7 @@
               </div>
               <!-- Weekly Reflection -->
               <div id="weekly-reflection" class="sticky-note white tape">
-                <h3 class="widget-title highlight-on-parent-hover">
+                <h3 class="widget-title">
                   Weekly Reflection
                 </h3>
               </div>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -859,6 +859,159 @@ async function initFocusMode() {
   });
 }
 
+function getTodayDateRangeIso() {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { startIso: start.toISOString(), endIso: end.toISOString() };
+}
+
+function formatFocusDuration(durationMs) {
+  const totalMinutes = Math.round((Number(durationMs) || 0) / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours <= 0) return `${minutes} min`;
+  if (minutes <= 0) return `${hours} hr`;
+  return `${hours} hr ${minutes} min`;
+}
+
+function renderDailyReflectionStats({
+  dateLabel,
+  tasksFocused = "—",
+  focusTimeLabel = "—",
+  completionRate = "—",
+} = {}) {
+  const dateEl = document.getElementById("dailyReflectionDate");
+  const tasksEl = document.getElementById("dailyReflectionTasksFocused");
+  const timeEl = document.getElementById("dailyReflectionFocusTime");
+  const completionEl = document.getElementById("dailyReflectionCompletionRate");
+
+  if (!dateEl || !tasksEl || !timeEl || !completionEl) return;
+
+  dateEl.textContent = dateLabel || new Date().toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  tasksEl.textContent = String(tasksFocused);
+  timeEl.textContent = String(focusTimeLabel);
+  completionEl.textContent = String(completionRate);
+}
+
+async function refreshDailyReflectionStats() {
+  const dateEl = document.getElementById("dailyReflectionDate");
+  const tasksEl = document.getElementById("dailyReflectionTasksFocused");
+  const timeEl = document.getElementById("dailyReflectionFocusTime");
+  const completionEl = document.getElementById("dailyReflectionCompletionRate");
+
+  if (!dateEl || !tasksEl || !timeEl || !completionEl) return;
+
+  const todayLabel = new Date().toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  renderDailyReflectionStats({
+    dateLabel: todayLabel,
+    tasksFocused: "…",
+    focusTimeLabel: "…",
+    completionRate: "…",
+  });
+
+  try {
+    const { startIso, endIso } = getTodayDateRangeIso();
+    const focusQuery = new URLSearchParams({ from: startIso, to: endIso }).toString();
+
+    const [tasksResponse, sessionsResponse] = await Promise.all([
+      apiFetch("/tasks", { credentials: "include", cache: "no-store" }),
+      apiFetch(`/focus-sessions?${focusQuery}`, {
+        credentials: "include",
+        cache: "no-store",
+      }),
+    ]);
+
+    const [tasksData, sessionsData] = await Promise.all([
+      parseApiResponse(tasksResponse),
+      parseApiResponse(sessionsResponse),
+    ]);
+
+    if (!tasksResponse.ok) {
+      throw new Error(tasksData?.error || "Could not load tasks");
+    }
+    if (!sessionsResponse.ok) {
+      throw new Error(sessionsData?.error || "Could not load focus sessions");
+    }
+
+    const tasks = Array.isArray(tasksData) ? tasksData : [];
+    const sessions = Array.isArray(sessionsData) ? sessionsData : [];
+
+    const focusedTaskIds = new Set(
+      sessions
+        .map((session) => session?.taskId)
+        .filter((taskId) => taskId !== null && taskId !== undefined)
+        .map((taskId) => String(taskId)),
+    );
+
+    const totalFocusMs = sessions.reduce(
+      (sum, session) => sum + (Number(session?.durationMs) || 0),
+      0,
+    );
+
+    const todayStart = new Date(startIso).getTime();
+    const todayEnd = new Date(endIso).getTime();
+
+    const tasksCreatedToday = tasks.filter((task) => {
+      const createdAtMs = new Date(task?.createdAt || "").getTime();
+      return Number.isFinite(createdAtMs) && createdAtMs >= todayStart && createdAtMs < todayEnd;
+    }).length;
+
+    const completedToday = tasks.filter((task) => {
+      if (task?.status !== "completed") return false;
+      const completedAtMs = new Date(task?.completedAt || "").getTime();
+      return Number.isFinite(completedAtMs) && completedAtMs >= todayStart && completedAtMs < todayEnd;
+    }).length;
+
+    const completionRate = tasksCreatedToday > 0
+      ? `${Math.round((completedToday / tasksCreatedToday) * 100)}%`
+      : "0%";
+
+    renderDailyReflectionStats({
+      dateLabel: todayLabel,
+      tasksFocused: focusedTaskIds.size,
+      focusTimeLabel: formatFocusDuration(totalFocusMs),
+      completionRate,
+    });
+  } catch (error) {
+    console.error("Could not refresh daily reflection stats:", error);
+    renderDailyReflectionStats({
+      dateLabel: todayLabel,
+      tasksFocused: "—",
+      focusTimeLabel: "—",
+      completionRate: "—",
+    });
+  }
+}
+
+function initDailyReflectionStatsWidget() {
+  const dateEl = document.getElementById("dailyReflectionDate");
+  if (!dateEl) return;
+
+  refreshDailyReflectionStats();
+
+  window.setInterval(refreshDailyReflectionStats, 60000);
+
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) refreshDailyReflectionStats();
+  });
+
+  window.addEventListener("focus", refreshDailyReflectionStats);
+}
+
 async function initDailyEmailSettings() {
   const toggleEl = document.getElementById("dailyEmailToggle");
   const timeEl = document.getElementById("dailyEmailTime");
@@ -1308,6 +1461,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   bindDashboardTaskFilterTabs();
   initDailyEmailSettings();
+  initDailyReflectionStatsWidget();
 
   checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
   initFocusMode();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -416,17 +416,18 @@ function updateFocusTaskOptions(tasks) {
 
     if (taskListEl) {
       const emptyItem = document.createElement("li");
-      emptyItem.className = "big-three-item focus-task-empty";
+      emptyItem.className = "big-three-item focus-task-list-item focus-task-empty";
 
-      const message = document.createElement("span");
-      message.textContent = "You have no active tasks. ";
+      const sentence = document.createElement("span");
+      sentence.textContent = "You have no active tasks. ";
 
       const createTaskLink = document.createElement("a");
       createTaskLink.href = "/dashboard.html";
       createTaskLink.className = "focus-task-empty-link highlight-on-parent-hover";
       createTaskLink.textContent = "Make one now!";
 
-      emptyItem.append(message, createTaskLink);
+      sentence.append(createTaskLink);
+      emptyItem.append(sentence);
       taskListEl.appendChild(emptyItem);
     }
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -411,13 +411,22 @@ function updateFocusTaskOptions(tasks) {
   if (filteredTasks.length === 0) {
     const option = document.createElement("option");
     option.value = "";
-    option.textContent = "No active tasks";
+    option.textContent = "You have no active tasks. Make one now!";
     selectEl.appendChild(option);
 
     if (taskListEl) {
       const emptyItem = document.createElement("li");
       emptyItem.className = "big-three-item focus-task-empty";
-      emptyItem.textContent = "No active tasks";
+
+      const message = document.createElement("span");
+      message.textContent = "You have no active tasks. ";
+
+      const createTaskLink = document.createElement("a");
+      createTaskLink.href = "/dashboard.html";
+      createTaskLink.className = "focus-task-empty-link highlight-on-parent-hover";
+      createTaskLink.textContent = "Make one now!";
+
+      emptyItem.append(message, createTaskLink);
       taskListEl.appendChild(emptyItem);
     }
 

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -107,23 +107,6 @@
             <button id="dailyEmailTestBtn" class="btn" type="button">Test</button>
           </div>
 
-          <section class="daily-reflection-today" aria-live="polite" aria-label="Today's reflection stats">
-            <p id="dailyReflectionDate" class="daily-reflection-today-date"></p>
-            <ul class="daily-reflection-metrics" role="list">
-              <li>
-                <span class="daily-reflection-metric-label">Tasks focused on:</span>
-                <span id="dailyReflectionTasksFocused" class="daily-reflection-metric-value">—</span>
-              </li>
-              <li>
-                <span class="daily-reflection-metric-label">Task focus time:</span>
-                <span id="dailyReflectionFocusTime" class="daily-reflection-metric-value">—</span>
-              </li>
-              <li>
-                <span class="daily-reflection-metric-label">Task completion rate:</span>
-                <span id="dailyReflectionCompletionRate" class="daily-reflection-metric-value">—</span>
-              </li>
-            </ul>
-          </section>
         </section>
       </section>
     </main>

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -106,6 +106,24 @@
 
             <button id="dailyEmailTestBtn" class="btn" type="button">Test</button>
           </div>
+
+          <section class="daily-reflection-today" aria-live="polite" aria-label="Today's reflection stats">
+            <p id="dailyReflectionDate" class="daily-reflection-today-date"></p>
+            <ul class="daily-reflection-metrics" role="list">
+              <li>
+                <span class="daily-reflection-metric-label">Tasks focused on:</span>
+                <span id="dailyReflectionTasksFocused" class="daily-reflection-metric-value">—</span>
+              </li>
+              <li>
+                <span class="daily-reflection-metric-label">Task focus time:</span>
+                <span id="dailyReflectionFocusTime" class="daily-reflection-metric-value">—</span>
+              </li>
+              <li>
+                <span class="daily-reflection-metric-label">Task completion rate:</span>
+                <span id="dailyReflectionCompletionRate" class="daily-reflection-metric-value">—</span>
+              </li>
+            </ul>
+          </section>
         </section>
       </section>
     </main>


### PR DESCRIPTION
### Motivation
- Improve the focus-mode empty state by centering the session status and giving users a clear call-to-action that links to the dashboard when there are no active tasks.

### Description
- Update `updateFocusTaskOptions` (`public/js/main.js`) to change the fallback option text to "You have no active tasks. Make one now!" and render an empty-list `li` that contains a message span and an anchor to `/dashboard.html` with classes `focus-task-empty-link highlight-on-parent-hover`.
- Add CSS in `public/css/focus-page.css` to center `#focus-mode-widget .focus-status`, center `.focus-task-empty`, and style `.focus-task-empty-link` to inherit color, remove underline, and emphasize the CTA.
- Preserve existing control behavior by continuing to call `updateFocusModeControls` with `hasTask: false` when the filtered task list is empty.

### Testing
- Ran `node --check public/js/main.js`, which succeeded.
- Attempted `npm start` and an automated Playwright screenshot, but the app could not be started in this environment due to missing dependencies (`Cannot find module 'lusca'`) and `npm install` failing with a `403` for `express-rate-limit`, so end-to-end verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b433ca6d908326a7fce222c29a386c)