### PR TITLE
Keep settings time input contained within white card

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1896,7 +1896,7 @@ body.task-panel-open {
 
 .daily-email-time-row {
   padding-left: 0;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: center;
 }
 
@@ -1921,6 +1921,7 @@ body.task-panel-open {
   margin-left: 0;
   flex: 0 0 auto;
   width: 8.5rem;
+  max-width: 100%;
 }
 
 .daily-reflection-today {


### PR DESCRIPTION
### Motivation

- Prevent the daily email time control from overflowing the white settings card at narrow widths by allowing the layout to wrap and the control to respect container width.

### Description

- Changed `.daily-email-time-row` to `flex-wrap: wrap` so the time row can stack instead of forcing a single line (file: `public/css/main.css`).
- Added `max-width: 100%` to `#dailyEmailTime` to constrain the time input to its parent container (file: `public/css/main.css`).

### Testing

- Started a static server with `python3 -m http.server` and loaded `/settings-page.html`, which served successfully and exercised the updated CSS.
- Ran a Playwright script to open the settings page and capture a screenshot to validate the time input stays inside the white card, and the screenshot was produced successfully.
- Verified the CSS diff in `public/css/main.css` to confirm the intended changes were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5a054c290832680aeed5101ef868b)