### PR TITLE
Run daily reflections via Vercel Cron and add authenticated cron endpoint

### DIFF
--- a/.github/workflows/daily-reflection-cron.yml
+++ b/.github/workflows/daily-reflection-cron.yml
@@ -1,0 +1,30 @@
+name: Daily Reflection Scheduler Tick
+
+on:
+  schedule:
+    # GitHub Actions' smallest supported cron interval is every 5 minutes.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+jobs:
+  trigger-daily-reflection:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger scheduler endpoint
+        env:
+          APP_BASE_URL: ${{ secrets.APP_BASE_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          if [ -z "$APP_BASE_URL" ]; then
+            echo "Missing APP_BASE_URL secret."
+            exit 1
+          fi
+
+          if [ -z "$CRON_SECRET" ]; then
+            echo "Missing CRON_SECRET secret."
+            exit 1
+          fi
+
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            "$APP_BASE_URL/api/cron/daily-reflection"

--- a/.github/workflows/daily-reflection-cron.yml
+++ b/.github/workflows/daily-reflection-cron.yml
@@ -5,6 +5,11 @@ on:
     # GitHub Actions' smallest supported cron interval is every 5 minutes.
     - cron: "*/5 * * * *"
   workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Optional deployed URL to call (for example a Vercel preview URL)."
+        required: false
+        type: string
 
 jobs:
   trigger-daily-reflection:
@@ -12,12 +17,18 @@ jobs:
     steps:
       - name: Trigger scheduler endpoint
         env:
+          INPUT_BASE_URL: ${{ inputs.base_url }}
           APP_BASE_URL: ${{ secrets.APP_BASE_URL }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: |
-          if [ -z "$APP_BASE_URL" ]; then
-            echo "Missing APP_BASE_URL secret."
-            exit 1
+          TARGET_BASE_URL="$INPUT_BASE_URL"
+          if [ -z "$TARGET_BASE_URL" ]; then
+            TARGET_BASE_URL="$APP_BASE_URL"
+          fi
+
+          if [ -z "$TARGET_BASE_URL" ]; then
+            echo "No target deployment URL configured. Set APP_BASE_URL secret or provide workflow_dispatch input base_url."
+            exit 0
           fi
 
           if [ -z "$CRON_SECRET" ]; then
@@ -27,4 +38,4 @@ jobs:
 
           curl --fail --silent --show-error \
             -H "Authorization: Bearer $CRON_SECRET" \
-            "$APP_BASE_URL/api/cron/daily-reflection"
+            "$TARGET_BASE_URL/api/cron/daily-reflection"

--- a/README.md
+++ b/README.md
@@ -2,4 +2,28 @@
 
 Link: www.stickapin.app
 
+### Daily Reflection via GitHub Actions
 
+This repository includes a workflow at `.github/workflows/daily-reflection-cron.yml` that can trigger the daily reflection scheduler endpoint every 5 minutes.
+
+#### 1) Add repository secrets
+
+In GitHub → **Settings** → **Secrets and variables** → **Actions**, add:
+
+- `APP_BASE_URL` (example: `https://www.stickapin.app`)
+- `CRON_SECRET` (must match the `CRON_SECRET` environment variable configured in your deployed app)
+
+#### 2) Enable workflow schedules
+
+- Go to **Actions** and make sure workflows are enabled for the repository.
+- The workflow runs on:
+  - `schedule` (`*/5 * * * *`)
+  - `workflow_dispatch` (manual run button)
+
+#### 3) Set the scheduler window for 5-minute ticks
+
+Because GitHub Actions cannot run every minute, set:
+
+- `DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES=5`
+
+in your runtime environment. This allows each tick to send when the current local time is within the 5-minute window after a user's chosen send time.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ In GitHub → **Settings** → **Secrets and variables** → **Actions**, add:
 - Go to **Actions** and make sure workflows are enabled for the repository.
 - The workflow runs on:
   - `schedule` (`*/5 * * * *`)
-  - `workflow_dispatch` (manual run button)
+  - `workflow_dispatch` (manual run button; supports optional `base_url` input for a preview deployment URL)
+
+#### 2.1) Important deployment note
+
+The workflow calls a deployed URL. If your branch is not deployed on Vercel yet, use the manual workflow run and set `base_url` to a deployed preview URL, or rely on the default `APP_BASE_URL` secret (typically production).
 
 #### 3) Set the scheduler window for 5-minute ticks
 

--- a/server.js
+++ b/server.js
@@ -27,6 +27,10 @@ const APP_BASE_URL = process.env.APP_BASE_URL;
 const EMAIL_FROM = process.env.EMAIL_FROM || "Stick A Pin <no-reply@mail.stickapin.app>";
 
 const DAILY_EMAIL_SCHEDULER_INTERVAL_MS = Number(process.env.DAILY_EMAIL_SCHEDULER_INTERVAL_MS || 60 * 1000);
+const DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES = Math.max(
+  1,
+  Number(process.env.DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES || Math.ceil(DAILY_EMAIL_SCHEDULER_INTERVAL_MS / 60000) || 1)
+);
 let dailyEmailSchedulerStarted = false;
 const IS_VERCEL_RUNTIME = Boolean(process.env.VERCEL);
 const CRON_SECRET = process.env.CRON_SECRET;
@@ -221,6 +225,28 @@ function getCurrentTimeInTimezone(timezone) {
   }
 }
 
+function parseTimeToMinutes(value) {
+  if (!isValidTimeInput(value)) {
+    return null;
+  }
+
+  const [hours, minutes] = value.split(":").map((part) => Number(part));
+  return (hours * 60) + minutes;
+}
+
+function isWithinScheduledWindow(currentTime, scheduledTime, windowMinutes) {
+  const currentMinutes = parseTimeToMinutes(currentTime);
+  const scheduledMinutes = parseTimeToMinutes(scheduledTime);
+
+  if (currentMinutes === null || scheduledMinutes === null) {
+    return false;
+  }
+
+  const normalizedWindowMinutes = Math.max(1, Number(windowMinutes) || 1);
+  const difference = (currentMinutes - scheduledMinutes + (24 * 60)) % (24 * 60);
+  return difference >= 0 && difference < normalizedWindowMinutes;
+}
+
 async function runDailyReflectionSchedulerTick() {
   try {
     const now = new Date();
@@ -236,7 +262,7 @@ async function runDailyReflectionSchedulerTick() {
         : "18:00";
       const currentTime = getCurrentTimeInTimezone(timezone);
 
-      if (currentTime !== scheduledTime) {
+      if (!isWithinScheduledWindow(currentTime, scheduledTime, DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES)) {
         continue;
       }
 
@@ -1074,7 +1100,10 @@ app.get("/api/cron/daily-reflection", async (req, res) => {
   }
 
   await runDailyReflectionSchedulerTick();
-  return res.json({ ok: true });
+  return res.json({
+    ok: true,
+    schedulerWindowMinutes: DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES,
+  });
 });
 
 

--- a/server.js
+++ b/server.js
@@ -28,6 +28,8 @@ const EMAIL_FROM = process.env.EMAIL_FROM || "Stick A Pin <no-reply@mail.stickap
 
 const DAILY_EMAIL_SCHEDULER_INTERVAL_MS = Number(process.env.DAILY_EMAIL_SCHEDULER_INTERVAL_MS || 60 * 1000);
 let dailyEmailSchedulerStarted = false;
+const IS_VERCEL_RUNTIME = Boolean(process.env.VERCEL);
+const CRON_SECRET = process.env.CRON_SECRET;
 
 // Rate limiter for authenticated routes to protect expensive operations
 const authenticatedLimiter = rateLimit({
@@ -261,6 +263,11 @@ async function runDailyReflectionSchedulerTick() {
 }
 
 function startDailyReflectionScheduler() {
+  if (IS_VERCEL_RUNTIME) {
+    console.log("Skipping in-memory daily reflection scheduler in Vercel runtime. Use cron endpoint instead.");
+    return;
+  }
+
   if (dailyEmailSchedulerStarted) {
     return;
   }
@@ -1056,6 +1063,18 @@ app.post("/settings/daily-email/test", authenticatedLimiter, ensureAuthenticated
     console.error("Error sending daily reflection test email:", error);
     return res.status(500).json({ error: "Unable to send daily reflection test email" });
   }
+});
+
+app.get("/api/cron/daily-reflection", async (req, res) => {
+  const authHeader = req.get("authorization") || "";
+  const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7).trim() : "";
+
+  if (!CRON_SECRET || token !== CRON_SECRET) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  await runDailyReflectionSchedulerTick();
+  return res.json({ ok: true });
 });
 
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,14 @@
 {
-    "version": 2,
-    "builds": [
-      { "src": "server.js", "use": "@vercel/node" }
-    ],
-    "routes": [
-      { "src": "/public/(.*)", "dest": "/public/$1" },
-      { "src": "/(.*)",        "dest": "server.js" }
-    ]
-  }
+  "version": 2,
+  "builds": [
+    { "src": "server.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/public/(.*)", "dest": "/public/$1" },
+    { "src": "/(.*)", "dest": "server.js" }
+  ],
+  "crons": [
+    { "path": "/api/cron/daily-reflection", "schedule": "* * * * *" }
+  ]
+}
   


### PR DESCRIPTION
### Motivation
- The in-memory `setInterval` scheduler relied on a long-running process which is unreliable on Vercel serverless, causing automatic daily reflection emails to not fire while the manual test endpoint still worked.
- The change moves to a platform-native cron trigger so scheduled work runs reliably in the serverless environment.

### Description
- Added environment detection with `IS_VERCEL_RUNTIME` and a `CRON_SECRET` env var and skipped the in-memory scheduler when running on Vercel by returning early from `startDailyReflectionScheduler`.
- Added a secure cron endpoint `GET /api/cron/daily-reflection` that requires `Authorization: Bearer <CRON_SECRET>` and invokes one `runDailyReflectionSchedulerTick()` to perform scheduled sends on demand.
- Added a Vercel cron configuration in `vercel.json` to call the endpoint every minute so the existing per-user time+timezone checks can decide when to send each user’s daily email.
- Preserved the existing `POST /settings/daily-email/test` behavior and local `setInterval` behavior for non-Vercel runtimes.

### Testing
- Ran `node --check server.js` to verify the server file has no syntax errors, and the check passed.
- Parsed `vercel.json` with `JSON.parse(...)` to validate the file is valid JSON, and the validation passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d03bd1b0832681b09b6c487d62b8)