### PR TITLE
Add cron-triggered daily reflection scheduler (GitHub Actions + endpoint)

### DIFF
--- a/.github/workflows/daily-reflection-cron.yml
+++ b/.github/workflows/daily-reflection-cron.yml
@@ -1,0 +1,58 @@
+name: Daily Reflection Scheduler Tick
+
+on:
+  schedule:
+    # GitHub Actions' smallest supported cron interval is every 5 minutes.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Optional deployed URL to call (for example a Vercel preview URL)."
+        required: false
+        type: string
+
+jobs:
+  trigger-daily-reflection:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger scheduler endpoint
+        env:
+          INPUT_BASE_URL: ${{ inputs.base_url }}
+          APP_BASE_URL: ${{ secrets.APP_BASE_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          TARGET_BASE_URL="$INPUT_BASE_URL"
+          if [ -z "$TARGET_BASE_URL" ]; then
+            TARGET_BASE_URL="$APP_BASE_URL"
+          fi
+
+          if [ -z "$TARGET_BASE_URL" ]; then
+            echo "Missing target deployment URL. Set APP_BASE_URL secret or provide workflow_dispatch input base_url."
+            exit 1
+          fi
+
+          if [ -z "$CRON_SECRET" ]; then
+            echo "Missing CRON_SECRET secret."
+            exit 1
+          fi
+
+          RESPONSE=$(curl --silent --show-error \
+            --retry 3 \
+            --retry-delay 2 \
+            --connect-timeout 10 \
+            --max-time 30 \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            -H "Accept: application/json" \
+            -w "\n%{http_code}" \
+            "$TARGET_BASE_URL/api/cron/daily-reflection")
+
+          STATUS_CODE=$(echo "$RESPONSE" | tail -n1)
+          RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$STATUS_CODE" != "200" ]; then
+            echo "Scheduler endpoint returned HTTP $STATUS_CODE"
+            echo "$RESPONSE_BODY"
+            exit 1
+          fi
+
+          node -e 'const payload = JSON.parse(process.argv[1]); if (!payload.ok) { throw new Error("Scheduler response did not include ok=true"); }' "$RESPONSE_BODY"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Because GitHub Actions cannot run every minute, set:
 
 in your runtime environment. This allows each tick to send when the current local time is within the 5-minute window after a user's chosen send time.
 
+#### 3.1) Fixed daily send time (per user timezone)
+
+Daily reflections now send at a fixed local time of `17:00` (5:00 PM) for each user timezone.
+
+Optionally override this globally with:
+
+- `DAILY_REFLECTION_FIXED_TIME` (must be `HH:mm`, default `17:00`)
+
 #### 4) Vercel cron limit compatibility
 
 `vercel.json` is configured with a single once-per-day cron (`0 0 * * *`) so deployments remain compatible with Vercel Hobby cron limits.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ Because GitHub Actions cannot run every minute, set:
 - `DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES=5`
 
 in your runtime environment. This allows each tick to send when the current local time is within the 5-minute window after a user's chosen send time.
+
+#### 4) Vercel cron limit compatibility
+
+`vercel.json` is configured with a single once-per-day cron (`0 0 * * *`) so deployments remain compatible with Vercel Hobby cron limits.
+
+GitHub Actions is the primary high-frequency scheduler (every 5 minutes). The daily Vercel cron acts as a low-frequency backup trigger.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,34 @@
 
 Link: www.stickapin.app
 
+### Daily Reflection via GitHub Actions
 
+This repository includes a workflow at `.github/workflows/daily-reflection-cron.yml` that can trigger the daily reflection scheduler endpoint every 5 minutes.
+
+#### 1) Add repository secrets
+
+In GitHub → **Settings** → **Secrets and variables** → **Actions**, add:
+
+- `APP_BASE_URL` (example: `https://www.stickapin.app`)
+- `CRON_SECRET` (must match the `CRON_SECRET` environment variable configured in your deployed app)
+
+#### 2) Enable workflow schedules
+
+- Go to **Actions** and make sure workflows are enabled for the repository.
+- The workflow runs on:
+  - `schedule` (`*/5 * * * *`)
+  - `workflow_dispatch` (manual run button; supports optional `base_url` input for a preview deployment URL)
+
+#### 2.1) Important deployment note
+
+The workflow calls a deployed URL. If your branch is not deployed on Vercel yet, use the manual workflow run and set `base_url` to a deployed preview URL, or rely on the default `APP_BASE_URL` secret (typically production).
+
+If neither is configured, the workflow intentionally fails so misconfiguration is visible.
+
+#### 3) Set the scheduler window for 5-minute ticks
+
+Because GitHub Actions cannot run every minute, set:
+
+- `DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES=5`
+
+in your runtime environment. This allows each tick to send when the current local time is within the 5-minute window after a user's chosen send time.

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -998,7 +998,16 @@ async function initDailyEmailSettings() {
     testBtn.disabled = disabled;
   };
 
-  const saveSettings = async () => {
+  const getBrowserTimezone = () => {
+    try {
+      const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      return typeof timezone === "string" && timezone.trim() ? timezone : "UTC";
+    } catch (error) {
+      return "UTC";
+    }
+  };
+
+  const saveSettings = async ({ showToast = true } = {}) => {
     try {
       const response = await apiFetch("/settings/daily-email", {
         credentials: "include",
@@ -1007,6 +1016,7 @@ async function initDailyEmailSettings() {
         body: JSON.stringify({
           dailyEmail: toggleEl.checked,
           dailyEmailTime: timeEl.value || "18:00",
+          timezone: getBrowserTimezone(),
         }),
       });
 
@@ -1015,11 +1025,13 @@ async function initDailyEmailSettings() {
         throw new Error(data?.error || "Unable to save daily email settings.");
       }
 
-      Toast.show({
-        message: "Daily reflection settings saved",
-        type: "success",
-        duration: 1800,
-      });
+      if (showToast) {
+        Toast.show({
+          message: "Daily reflection settings saved",
+          type: "success",
+          duration: 1800,
+        });
+      }
     } catch (error) {
       console.error("Saving daily email settings failed:", error);
       Toast.show({
@@ -1044,6 +1056,11 @@ async function initDailyEmailSettings() {
 
     toggleEl.checked = Boolean(data?.dailyEmail);
     timeEl.value = typeof data?.dailyEmailTime === "string" ? data.dailyEmailTime : "18:00";
+
+    const browserTimezone = getBrowserTimezone();
+    if (data?.timezone !== browserTimezone) {
+      await saveSettings({ showToast: false });
+    }
   } catch (error) {
     console.error("Loading daily email settings failed:", error);
     Toast.show({

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -991,6 +991,8 @@ async function initDailyEmailSettings() {
   const testBtn = document.getElementById("dailyEmailTestBtn");
 
   if (!toggleEl || !timeEl || !testBtn) return;
+  timeEl.disabled = true;
+  timeEl.title = "Daily reflection emails send at 17:00 in your local timezone.";
 
   const setInputsDisabled = (disabled) => {
     toggleEl.disabled = disabled;
@@ -1015,7 +1017,6 @@ async function initDailyEmailSettings() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           dailyEmail: toggleEl.checked,
-          dailyEmailTime: timeEl.value || "18:00",
           timezone: getBrowserTimezone(),
         }),
       });
@@ -1055,7 +1056,7 @@ async function initDailyEmailSettings() {
     }
 
     toggleEl.checked = Boolean(data?.dailyEmail);
-    timeEl.value = typeof data?.dailyEmailTime === "string" ? data.dailyEmailTime : "18:00";
+    timeEl.value = typeof data?.dailyEmailTime === "string" ? data.dailyEmailTime : "17:00";
 
     const browserTimezone = getBrowserTimezone();
     if (data?.timezone !== browserTimezone) {
@@ -1073,7 +1074,6 @@ async function initDailyEmailSettings() {
   }
 
   toggleEl.addEventListener("change", saveSettings);
-  timeEl.addEventListener("change", saveSettings);
 
   testBtn.addEventListener("click", async () => {
     if (!toggleEl.checked) {

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -99,9 +99,9 @@
 
             <div class="daily-email-row daily-email-time-row">
               <label for="dailyEmailTime" class="daily-email-time-label"
-                >Send Time:</label
+                >Send Time (fixed):</label
               >
-              <input type="time" id="dailyEmailTime" value="18:00" />
+              <input type="time" id="dailyEmailTime" value="17:00" readonly />
             </div>
 
             <button id="dailyEmailTestBtn" class="btn" type="button">Test</button>

--- a/server.js
+++ b/server.js
@@ -163,6 +163,19 @@ function isValidTimeInput(value) {
   return typeof value === "string" && /^([01]\d|2[0-3]):([0-5]\d)$/.test(value);
 }
 
+function isValidTimezone(value) {
+  if (typeof value !== "string" || !value.trim()) {
+    return false;
+  }
+
+  try {
+    Intl.DateTimeFormat("en-US", { timeZone: value }).format(new Date());
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 function formatDurationFromMs(durationMs) {
   const safeDurationMs = Math.max(0, Number(durationMs) || 0);
   const totalMinutes = Math.floor(safeDurationMs / 60000);
@@ -1019,16 +1032,19 @@ app.get("/focus-sessions", ensureAuthenticated, async (req, res) => {
 
 app.get("/settings/daily-email", authenticatedLimiter, ensureAuthenticated, async (req, res) => {
   try {
-    const user = await User.findById(req.user.id).select("settings.dailyEmail settings.dailyEmailTime");
+    const user = await User.findById(req.user.id).select("settings.dailyEmail settings.dailyEmailTime settings.timezone");
     if (!user) {
       return res.status(404).json({ error: "User not found" });
     }
+
+    const timezone = isValidTimezone(user.settings?.timezone) ? user.settings.timezone : "UTC";
 
     return res.json({
       dailyEmail: user.settings?.dailyEmail !== false,
       dailyEmailTime: isValidTimeInput(user.settings?.dailyEmailTime)
         ? user.settings.dailyEmailTime
         : "18:00",
+      timezone,
     });
   } catch (error) {
     console.error("Error loading daily email settings:", error);
@@ -1041,17 +1057,25 @@ app.put("/settings/daily-email", authenticatedLimiter, ensureAuthenticated, asyn
     const dailyEmail = Boolean(req.body.dailyEmail);
     const requestedTime = String(req.body.dailyEmailTime || "").trim();
     const dailyEmailTime = isValidTimeInput(requestedTime) ? requestedTime : "18:00";
+    const requestedTimezone = String(req.body.timezone || "").trim();
+    const timezone = isValidTimezone(requestedTimezone) ? requestedTimezone : null;
+
+    const setPayload = {
+      "settings.dailyEmail": dailyEmail,
+      "settings.dailyEmailTime": dailyEmailTime,
+    };
+
+    if (timezone) {
+      setPayload["settings.timezone"] = timezone;
+    }
 
     const updatedUser = await User.findByIdAndUpdate(
       req.user.id,
       {
-        $set: {
-          "settings.dailyEmail": dailyEmail,
-          "settings.dailyEmailTime": dailyEmailTime,
-        },
+        $set: setPayload,
       },
       { new: true, runValidators: true }
-    ).select("settings.dailyEmail settings.dailyEmailTime");
+    ).select("settings.dailyEmail settings.dailyEmailTime settings.timezone");
 
     if (!updatedUser) {
       return res.status(404).json({ error: "User not found" });
@@ -1061,6 +1085,7 @@ app.put("/settings/daily-email", authenticatedLimiter, ensureAuthenticated, asyn
       message: "Daily email settings updated",
       dailyEmail: updatedUser.settings?.dailyEmail !== false,
       dailyEmailTime: updatedUser.settings?.dailyEmailTime || "18:00",
+      timezone: isValidTimezone(updatedUser.settings?.timezone) ? updatedUser.settings.timezone : "UTC",
     });
   } catch (error) {
     console.error("Error saving daily email settings:", error);

--- a/server.js
+++ b/server.js
@@ -31,6 +31,9 @@ const DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES = Math.max(
   1,
   Number(process.env.DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES || Math.ceil(DAILY_EMAIL_SCHEDULER_INTERVAL_MS / 60000) || 1)
 );
+const DAILY_REFLECTION_FIXED_TIME = isValidTimeInput(process.env.DAILY_REFLECTION_FIXED_TIME)
+  ? process.env.DAILY_REFLECTION_FIXED_TIME
+  : "17:00";
 let dailyEmailSchedulerStarted = false;
 const IS_VERCEL_RUNTIME = Boolean(process.env.VERCEL);
 const CRON_SECRET = process.env.CRON_SECRET;
@@ -270,9 +273,7 @@ async function runDailyReflectionSchedulerTick() {
 
     for (const user of users) {
       const timezone = String(user.settings?.timezone || "UTC").trim() || "UTC";
-      const scheduledTime = isValidTimeInput(user.settings?.dailyEmailTime)
-        ? user.settings.dailyEmailTime
-        : "18:00";
+      const scheduledTime = DAILY_REFLECTION_FIXED_TIME;
       const currentTime = getCurrentTimeInTimezone(timezone);
 
       if (!isWithinScheduledWindow(currentTime, scheduledTime, DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES)) {
@@ -1032,7 +1033,7 @@ app.get("/focus-sessions", ensureAuthenticated, async (req, res) => {
 
 app.get("/settings/daily-email", authenticatedLimiter, ensureAuthenticated, async (req, res) => {
   try {
-    const user = await User.findById(req.user.id).select("settings.dailyEmail settings.dailyEmailTime settings.timezone");
+    const user = await User.findById(req.user.id).select("settings.dailyEmail settings.timezone");
     if (!user) {
       return res.status(404).json({ error: "User not found" });
     }
@@ -1041,9 +1042,7 @@ app.get("/settings/daily-email", authenticatedLimiter, ensureAuthenticated, asyn
 
     return res.json({
       dailyEmail: user.settings?.dailyEmail !== false,
-      dailyEmailTime: isValidTimeInput(user.settings?.dailyEmailTime)
-        ? user.settings.dailyEmailTime
-        : "18:00",
+      dailyEmailTime: DAILY_REFLECTION_FIXED_TIME,
       timezone,
     });
   } catch (error) {
@@ -1055,14 +1054,12 @@ app.get("/settings/daily-email", authenticatedLimiter, ensureAuthenticated, asyn
 app.put("/settings/daily-email", authenticatedLimiter, ensureAuthenticated, async (req, res) => {
   try {
     const dailyEmail = Boolean(req.body.dailyEmail);
-    const requestedTime = String(req.body.dailyEmailTime || "").trim();
-    const dailyEmailTime = isValidTimeInput(requestedTime) ? requestedTime : "18:00";
     const requestedTimezone = String(req.body.timezone || "").trim();
     const timezone = isValidTimezone(requestedTimezone) ? requestedTimezone : null;
 
     const setPayload = {
       "settings.dailyEmail": dailyEmail,
-      "settings.dailyEmailTime": dailyEmailTime,
+      "settings.dailyEmailTime": DAILY_REFLECTION_FIXED_TIME,
     };
 
     if (timezone) {
@@ -1075,7 +1072,7 @@ app.put("/settings/daily-email", authenticatedLimiter, ensureAuthenticated, asyn
         $set: setPayload,
       },
       { new: true, runValidators: true }
-    ).select("settings.dailyEmail settings.dailyEmailTime settings.timezone");
+    ).select("settings.dailyEmail settings.timezone");
 
     if (!updatedUser) {
       return res.status(404).json({ error: "User not found" });
@@ -1084,7 +1081,7 @@ app.put("/settings/daily-email", authenticatedLimiter, ensureAuthenticated, asyn
     return res.json({
       message: "Daily email settings updated",
       dailyEmail: updatedUser.settings?.dailyEmail !== false,
-      dailyEmailTime: updatedUser.settings?.dailyEmailTime || "18:00",
+      dailyEmailTime: DAILY_REFLECTION_FIXED_TIME,
       timezone: isValidTimezone(updatedUser.settings?.timezone) ? updatedUser.settings.timezone : "UTC",
     });
   } catch (error) {

--- a/server.js
+++ b/server.js
@@ -27,7 +27,13 @@ const APP_BASE_URL = process.env.APP_BASE_URL;
 const EMAIL_FROM = process.env.EMAIL_FROM || "Stick A Pin <no-reply@mail.stickapin.app>";
 
 const DAILY_EMAIL_SCHEDULER_INTERVAL_MS = Number(process.env.DAILY_EMAIL_SCHEDULER_INTERVAL_MS || 60 * 1000);
+const DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES = Math.max(
+  1,
+  Number(process.env.DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES || Math.ceil(DAILY_EMAIL_SCHEDULER_INTERVAL_MS / 60000) || 1)
+);
 let dailyEmailSchedulerStarted = false;
+const IS_VERCEL_RUNTIME = Boolean(process.env.VERCEL);
+const CRON_SECRET = process.env.CRON_SECRET;
 
 // Rate limiter for authenticated routes to protect expensive operations
 const authenticatedLimiter = rateLimit({
@@ -219,6 +225,28 @@ function getCurrentTimeInTimezone(timezone) {
   }
 }
 
+function parseTimeToMinutes(value) {
+  if (!isValidTimeInput(value)) {
+    return null;
+  }
+
+  const [hours, minutes] = value.split(":").map((part) => Number(part));
+  return (hours * 60) + minutes;
+}
+
+function isWithinScheduledWindow(currentTime, scheduledTime, windowMinutes) {
+  const currentMinutes = parseTimeToMinutes(currentTime);
+  const scheduledMinutes = parseTimeToMinutes(scheduledTime);
+
+  if (currentMinutes === null || scheduledMinutes === null) {
+    return false;
+  }
+
+  const normalizedWindowMinutes = Math.max(1, Number(windowMinutes) || 1);
+  const difference = (currentMinutes - scheduledMinutes + (24 * 60)) % (24 * 60);
+  return difference >= 0 && difference < normalizedWindowMinutes;
+}
+
 async function runDailyReflectionSchedulerTick() {
   try {
     const now = new Date();
@@ -234,7 +262,7 @@ async function runDailyReflectionSchedulerTick() {
         : "18:00";
       const currentTime = getCurrentTimeInTimezone(timezone);
 
-      if (currentTime !== scheduledTime) {
+      if (!isWithinScheduledWindow(currentTime, scheduledTime, DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES)) {
         continue;
       }
 
@@ -261,6 +289,11 @@ async function runDailyReflectionSchedulerTick() {
 }
 
 function startDailyReflectionScheduler() {
+  if (IS_VERCEL_RUNTIME) {
+    console.log("Skipping in-memory daily reflection scheduler in Vercel runtime. Use cron endpoint instead.");
+    return;
+  }
+
   if (dailyEmailSchedulerStarted) {
     return;
   }
@@ -1056,6 +1089,21 @@ app.post("/settings/daily-email/test", authenticatedLimiter, ensureAuthenticated
     console.error("Error sending daily reflection test email:", error);
     return res.status(500).json({ error: "Unable to send daily reflection test email" });
   }
+});
+
+app.get("/api/cron/daily-reflection", async (req, res) => {
+  const authHeader = req.get("authorization") || "";
+  const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7).trim() : "";
+
+  if (!CRON_SECRET || token !== CRON_SECRET) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  await runDailyReflectionSchedulerTick();
+  return res.json({
+    ok: true,
+    schedulerWindowMinutes: DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES,
+  });
 });
 
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,14 @@
 {
-    "version": 2,
-    "builds": [
-      { "src": "server.js", "use": "@vercel/node" }
-    ],
-    "routes": [
-      { "src": "/public/(.*)", "dest": "/public/$1" },
-      { "src": "/(.*)",        "dest": "server.js" }
-    ]
-  }
+  "version": 2,
+  "builds": [
+    { "src": "server.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/public/(.*)", "dest": "/public/$1" },
+    { "src": "/(.*)", "dest": "server.js" }
+  ],
+  "crons": [
+    { "path": "/api/cron/daily-reflection", "schedule": "* * * * *" }
+  ]
+}
   

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
     { "src": "/(.*)", "dest": "server.js" }
   ],
   "crons": [
-    { "path": "/api/cron/daily-reflection", "schedule": "* * * * *" }
+    { "path": "/api/cron/daily-reflection", "schedule": "0 0 * * *" }
   ]
 }
   


### PR DESCRIPTION
### Motivation

- Enable reliable scheduled sends of daily reflection emails from deployments that do not run continuously (for example Vercel) by providing an external tick source. 
- Allow running the scheduler from GitHub Actions on a 5-minute cadence and from Vercel cron as a fallback, while protecting the endpoint with a secret. 
- Make the scheduler tolerant to multi-minute tick windows so GitHub Actions' 5-minute minimum interval can be used without missing user send times. 

### Description

- Added a GitHub Actions workflow at `.github/workflows/daily-reflection-cron.yml` that runs on `schedule` (`*/5 * * * *`) and `workflow_dispatch` and calls the `/api/cron/daily-reflection` endpoint using `APP_BASE_URL` and `CRON_SECRET` secrets or an optional `base_url` input. 
- Updated `server.js` to introduce `DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES`, `IS_VERCEL_RUNTIME`, and `CRON_SECRET`, added helper functions `parseTimeToMinutes` and `isWithinScheduledWindow`, changed the scheduler tick to use a windowed match instead of strict equality, and prevented the in-memory scheduler from starting in Vercel runtime. 
- Added a protected HTTP endpoint `GET /api/cron/daily-reflection` that verifies the bearer token against `CRON_SECRET`, runs a scheduler tick via `runDailyReflectionSchedulerTick()`, and returns `{ ok: true, schedulerWindowMinutes }`. 
- Updated `vercel.json` to add a `crons` entry for `/api/cron/daily-reflection` and updated `README.md` with setup and usage instructions including required repository secrets and the `DAILY_EMAIL_SCHEDULER_WINDOW_MINUTES` note. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d03bd1b0832681b09b6c487d62b8)