### PR TITLE
Fix server crash from duplicate rateLimit declaration

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,9 +10,8 @@ const bcrypt = require("bcryptjs"); // Used to hash passwords
 const User = require("./config/models/user"); // User model for the database
 const Task = require("./config/models/task"); // Task model for the database
 const FocusSession = require("./config/models/focusSession"); // FocusSession model for tracking focus sessions
-const rateLimit = require("express-rate-limit");
-const csrf = require("lusca").csrf; // CSRF protection middleware
 const rateLimit = require("express-rate-limit"); // Rate limiting middleware
+const csrf = require("lusca").csrf; // CSRF protection middleware
 const MongoStore = require("connect-mongo").default; // Store sessions in MongoDB
 
 


### PR DESCRIPTION
### Motivation
- Vercel startup logs showed `SyntaxError: Identifier 'rateLimit' has already been declared`, which caused the Node process to exit during module load and returned 500s for all requests, so the duplicate import needed to be removed to allow the server to start.

### Description
- Removed the duplicate `require("express-rate-limit")` declaration in `server.js` and kept a single `rateLimit` import alongside the `lusca` `csrf` import so the module no longer redeclares `rateLimit`.

### Testing
- Ran `node --check server.js` to validate syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ffdd020c83269a399cec869067fa)