### PR TITLE
Improve OAuth env handling and construct dynamic Google callback URL

### DIFF
--- a/config/passport-config.js
+++ b/config/passport-config.js
@@ -33,6 +33,32 @@ function splitName(profile = {}, fallbackEmail = "") {
   };
 }
 
+
+function readEnv(name) {
+  const value = process.env[name];
+  if (typeof value !== "string") return "";
+  return value.trim();
+}
+
+function firstEnv(names = []) {
+  for (const name of names) {
+    const value = readEnv(name);
+    if (value) return value;
+  }
+
+  return "";
+}
+
+function buildCallbackUrl(pathname) {
+  const explicitBaseUrl = readEnv("APP_BASE_URL");
+  const vercelUrl = readEnv("VERCEL_PROJECT_PRODUCTION_URL") || readEnv("VERCEL_URL");
+  const baseUrl = explicitBaseUrl || (vercelUrl ? `https://${vercelUrl.replace(/^https?:\/\//, "")}` : "");
+
+  if (!baseUrl) return "";
+
+  return `${baseUrl.replace(/\/$/, "")}${pathname}`;
+}
+
 module.exports = function (passport) {
   passport.use(
     new LocalStrategy(
@@ -66,9 +92,9 @@ module.exports = function (passport) {
     )
   );
 
-  const googleClientId = process.env.GOOGLE_CLIENT_ID;
-  const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
-  const googleCallbackURL = process.env.GOOGLE_CALLBACK_URL;
+  const googleClientId = firstEnv(["GOOGLE_CLIENT_ID"]);
+  const googleClientSecret = firstEnv(["GOOGLE_CLIENT_SECRET"]);
+  const googleCallbackURL = firstEnv(["GOOGLE_CALLBACK_URL"]) || buildCallbackUrl("/auth/google/callback");
 
   if (googleClientId && googleClientSecret && googleCallbackURL) {
     const GoogleStrategy = require("passport-google-oauth20").Strategy;

--- a/server.js
+++ b/server.js
@@ -10,9 +10,8 @@ const bcrypt = require("bcryptjs"); // Used to hash passwords
 const User = require("./config/models/user"); // User model for the database
 const Task = require("./config/models/task"); // Task model for the database
 const FocusSession = require("./config/models/focusSession"); // FocusSession model for tracking focus sessions
-const rateLimit = require("express-rate-limit");
-const csrf = require("lusca").csrf; // CSRF protection middleware
 const rateLimit = require("express-rate-limit"); // Rate limiting middleware
+const csrf = require("lusca").csrf; // CSRF protection middleware
 const MongoStore = require("connect-mongo").default; // Store sessions in MongoDB
 
 


### PR DESCRIPTION
### Motivation

- Ensure Google OAuth configuration is discovered reliably from multiple environment sources and provide a sensible default callback URL when not explicitly set.
- Avoid brittle assumptions about environment variable presence in deployments like Vercel by reading alternate env keys and trimming values.

### Description

- Added `readEnv`, `firstEnv`, and `buildCallbackUrl` helpers to `config/passport-config.js` to normalize environment reads and compute a callback URL from `APP_BASE_URL` or Vercel-provided URLs.
- Updated Google OAuth setup to use `firstEnv` for `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` and to fall back to `buildCallbackUrl('/auth/google/callback')` when `GOOGLE_CALLBACK_URL` is not set.
- Minor reordering/cleanup of require statements in `server.js` to consolidate middleware imports.

### Testing

- Ran the project linter via `npm run lint` and the existing test suite via `npm test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ffdd020c83269a399cec869067fa)