### PR TITLE
Make Google OAuth callback URL configurable and derive it dynamically from env or request

### DIFF
--- a/config/passport-config.js
+++ b/config/passport-config.js
@@ -33,6 +33,32 @@ function splitName(profile = {}, fallbackEmail = "") {
   };
 }
 
+
+function readEnv(name) {
+  const value = process.env[name];
+  if (typeof value !== "string") return "";
+  return value.trim();
+}
+
+function firstEnv(names = []) {
+  for (const name of names) {
+    const value = readEnv(name);
+    if (value) return value;
+  }
+
+  return "";
+}
+
+function buildCallbackUrl(pathname) {
+  const explicitBaseUrl = readEnv("APP_BASE_URL");
+  const vercelUrl = readEnv("VERCEL_PROJECT_PRODUCTION_URL") || readEnv("VERCEL_URL");
+  const baseUrl = explicitBaseUrl || (vercelUrl ? `https://${vercelUrl.replace(/^https?:\/\//, "")}` : "");
+
+  if (!baseUrl) return "";
+
+  return `${baseUrl.replace(/\/$/, "")}${pathname}`;
+}
+
 module.exports = function (passport) {
   passport.use(
     new LocalStrategy(
@@ -66,9 +92,9 @@ module.exports = function (passport) {
     )
   );
 
-  const googleClientId = process.env.GOOGLE_CLIENT_ID;
-  const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
-  const googleCallbackURL = process.env.GOOGLE_CALLBACK_URL;
+  const googleClientId = firstEnv(["GOOGLE_CLIENT_ID"]);
+  const googleClientSecret = firstEnv(["GOOGLE_CLIENT_SECRET"]);
+  const googleCallbackURL = firstEnv(["GOOGLE_CALLBACK_URL"]) || buildCallbackUrl("/auth/google/callback");
 
   if (googleClientId && googleClientSecret && googleCallbackURL) {
     const GoogleStrategy = require("passport-google-oauth20").Strategy;

--- a/server.js
+++ b/server.js
@@ -10,9 +10,8 @@ const bcrypt = require("bcryptjs"); // Used to hash passwords
 const User = require("./config/models/user"); // User model for the database
 const Task = require("./config/models/task"); // Task model for the database
 const FocusSession = require("./config/models/focusSession"); // FocusSession model for tracking focus sessions
-const rateLimit = require("express-rate-limit");
-const csrf = require("lusca").csrf; // CSRF protection middleware
 const rateLimit = require("express-rate-limit"); // Rate limiting middleware
+const csrf = require("lusca").csrf; // CSRF protection middleware
 const MongoStore = require("connect-mongo").default; // Store sessions in MongoDB
 
 
@@ -456,12 +455,28 @@ function redirectAuthFailure(req, res) {
   return res.redirect("/login.html?error=sso_failed");
 }
 
+
+function getGoogleCallbackUrlForRequest(req) {
+  const configuredCallback = (process.env.GOOGLE_CALLBACK_URL || "").trim();
+  if (configuredCallback) return configuredCallback;
+
+  const forwardedProto = String(req.headers["x-forwarded-proto"] || "").split(",")[0].trim();
+  const protocol = forwardedProto || req.protocol || (process.env.NODE_ENV === "production" ? "https" : "http");
+  const hostHeader = String(req.headers["x-forwarded-host"] || req.headers.host || "").split(",")[0].trim();
+  const canonicalHost = hostHeader.replace(/^www\./i, "");
+
+  if (!canonicalHost) return "/auth/google/callback";
+
+  return `${protocol}://${canonicalHost}/auth/google/callback`;
+}
+
 app.get("/auth/google", authRateLimiter, (req, res, next) => {
   if (!isStrategyEnabled("google")) {
     return res.status(503).json({ error: "Google login is not configured" });
   }
 
-  passport.authenticate("google", { scope: ["profile", "email"] })(req, res, next);
+  const callbackURL = getGoogleCallbackUrlForRequest(req);
+  passport.authenticate("google", { scope: ["profile", "email"], callbackURL })(req, res, next);
 });
 
 app.get("/auth/google/callback", authRateLimiter, (req, res, next) => {
@@ -469,7 +484,8 @@ app.get("/auth/google/callback", authRateLimiter, (req, res, next) => {
     return redirectAuthFailure(req, res);
   }
 
-  passport.authenticate("google", { failureRedirect: "/login.html?error=sso_failed" })(req, res, (authErr) => {
+  const callbackURL = getGoogleCallbackUrlForRequest(req);
+  passport.authenticate("google", { failureRedirect: "/login.html?error=sso_failed", callbackURL })(req, res, (authErr) => {
     if (authErr) return next(authErr);
     return res.redirect("/dashboard.html");
   });


### PR DESCRIPTION
### Motivation
- Ensure the Google OAuth `callbackURL` is robust across environments (local, Vercel, behind proxies) and not strictly tied to a single env var. 
- Provide sensible fallbacks when `GOOGLE_CALLBACK_URL` is not set, using `APP_BASE_URL`, Vercel URLs, or request headers. 
- Reduce brittle behavior when running behind proxies or with domain or protocol variations.

### Description
- Added utility helpers `readEnv`, `firstEnv`, and `buildCallbackUrl` to `config/passport-config.js` and switched to `firstEnv` plus `buildCallbackUrl` to compute `googleCallbackURL` with fallbacks to `APP_BASE_URL` and Vercel-provided envs. 
- Introduced `getGoogleCallbackUrlForRequest` in `server.js` to compute a request-specific callback URL using `X-Forwarded-*` headers, `req.protocol`, or `HOST` and to return a safe fallback `"/auth/google/callback"` when a host cannot be derived. 
- Plumbed the computed `callbackURL` into `passport.authenticate` calls for `/auth/google` and `/auth/google/callback` so OAuth redirects use the dynamically determined URL. 
- Minor cleanup/reordering of `require` lines for `rateLimit` and `csrf` in `server.js`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ffdd020c83269a399cec869067fa)