### PR TITLE
Add weekly reflection card metrics and live aggregation

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -272,6 +272,23 @@
                 <h3 class="widget-title">
                   Weekly Reflection
                 </h3>
+                <section class="daily-reflection-today" aria-live="polite" aria-label="This week's reflection stats">
+                  <p id="weeklyReflectionDate" class="daily-reflection-today-date"></p>
+                  <ul class="daily-reflection-metrics" role="list">
+                    <li>
+                      <span class="daily-reflection-metric-label">Total tasks focused on:</span>
+                      <span id="weeklyReflectionTasksFocused" class="daily-reflection-metric-value">—</span>
+                    </li>
+                    <li>
+                      <span class="daily-reflection-metric-label">Total time focused:</span>
+                      <span id="weeklyReflectionFocusTime" class="daily-reflection-metric-value">—</span>
+                    </li>
+                    <li>
+                      <span class="daily-reflection-metric-label">Total tasks completed:</span>
+                      <span id="weeklyReflectionTasksCompleted" class="daily-reflection-metric-value">—</span>
+                    </li>
+                  </ul>
+                </section>
               </div>
             </div>
           </div>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -875,6 +875,20 @@ function getTodayDateRangeIso() {
   return { startIso: start.toISOString(), endIso: end.toISOString() };
 }
 
+function getCurrentWeekDateRangeIso() {
+  const now = new Date();
+  const dayOfWeek = now.getDay();
+  const daysFromMonday = (dayOfWeek + 6) % 7;
+
+  const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
+  monday.setDate(monday.getDate() - daysFromMonday);
+
+  const nextMonday = new Date(monday);
+  nextMonday.setDate(nextMonday.getDate() + 7);
+
+  return { startIso: monday.toISOString(), endIso: nextMonday.toISOString(), monday };
+}
+
 function formatDailyFocusDuration(durationMs) {
   const totalMinutes = Math.round((Number(durationMs) || 0) / 60000);
   const hours = Math.floor(totalMinutes / 60);
@@ -910,6 +924,23 @@ function getCompletedTaskCountToday(tasks = []) {
   }, 0);
 }
 
+function getCompletedTaskCountInRange(tasks = [], startMs = 0, endMs = 0) {
+  if (!Array.isArray(tasks)) return 0;
+
+  return tasks.reduce((count, task) => {
+    if (task?.status !== "completed") return count;
+    const completedAt = new Date(task?.completedAt || 0).getTime();
+    if (
+      Number.isFinite(completedAt) &&
+      completedAt >= startMs &&
+      completedAt < endMs
+    ) {
+      return count + 1;
+    }
+    return count;
+  }, 0);
+}
+
 function renderDailyReflectionStats({
   dateLabel,
   tasksFocused = "—",
@@ -929,6 +960,25 @@ function renderDailyReflectionStats({
     day: "numeric",
     year: "numeric",
   });
+  tasksEl.textContent = String(tasksFocused);
+  timeEl.textContent = String(focusTimeLabel);
+  completedEl.textContent = String(tasksCompleted);
+}
+
+function renderWeeklyReflectionStats({
+  dateLabel,
+  tasksFocused = "—",
+  focusTimeLabel = "—",
+  tasksCompleted = "—",
+} = {}) {
+  const dateEl = document.getElementById("weeklyReflectionDate");
+  const tasksEl = document.getElementById("weeklyReflectionTasksFocused");
+  const timeEl = document.getElementById("weeklyReflectionFocusTime");
+  const completedEl = document.getElementById("weeklyReflectionTasksCompleted");
+
+  if (!dateEl || !tasksEl || !timeEl || !completedEl) return;
+
+  dateEl.textContent = dateLabel || "—";
   tasksEl.textContent = String(tasksFocused);
   timeEl.textContent = String(focusTimeLabel);
   completedEl.textContent = String(tasksCompleted);
@@ -1015,6 +1065,99 @@ async function refreshDailyReflectionStats() {
   }
 }
 
+async function refreshWeeklyReflectionStats() {
+  const dateEl = document.getElementById("weeklyReflectionDate");
+  const tasksEl = document.getElementById("weeklyReflectionTasksFocused");
+  const timeEl = document.getElementById("weeklyReflectionFocusTime");
+  const completedEl = document.getElementById("weeklyReflectionTasksCompleted");
+
+  if (!dateEl || !tasksEl || !timeEl || !completedEl) return;
+
+  const { startIso, endIso, monday } = getCurrentWeekDateRangeIso();
+  const sunday = new Date(monday);
+  sunday.setDate(sunday.getDate() + 6);
+
+  const weekLabel = `${monday.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })} - ${sunday.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })}`;
+
+  renderWeeklyReflectionStats({
+    dateLabel: weekLabel,
+    tasksFocused: "…",
+    focusTimeLabel: "…",
+    tasksCompleted: "…",
+  });
+
+  try {
+    const focusQuery = new URLSearchParams({ from: startIso, to: endIso }).toString();
+
+    const [sessionsResponse, tasksResponse] = await Promise.all([
+      apiFetch(`/focus-sessions?${focusQuery}`, {
+        credentials: "include",
+        cache: "no-store",
+      }),
+      apiFetch("/tasks", {
+        credentials: "include",
+        cache: "no-store",
+      }),
+    ]);
+
+    const [sessionsData, tasksData] = await Promise.all([
+      parseApiResponse(sessionsResponse),
+      parseApiResponse(tasksResponse),
+    ]);
+
+    if (!sessionsResponse.ok) {
+      throw new Error(sessionsData?.error || "Could not load focus sessions");
+    }
+    if (!tasksResponse.ok) {
+      throw new Error(tasksData?.error || "Could not load tasks");
+    }
+
+    const sessions = Array.isArray(sessionsData) ? sessionsData : [];
+    const tasks = Array.isArray(tasksData) ? tasksData : [];
+
+    const focusedTaskIds = new Set(
+      sessions
+        .map((session) => session?.taskId)
+        .filter((taskId) => taskId !== null && taskId !== undefined)
+        .map((taskId) => String(taskId)),
+    );
+
+    const totalFocusMs = sessions.reduce(
+      (sum, session) => sum + computeSessionDurationMs(session),
+      0,
+    );
+
+    renderWeeklyReflectionStats({
+      dateLabel: weekLabel,
+      tasksFocused: focusedTaskIds.size,
+      focusTimeLabel: formatDailyFocusDuration(totalFocusMs),
+      tasksCompleted: getCompletedTaskCountInRange(
+        tasks,
+        new Date(startIso).getTime(),
+        new Date(endIso).getTime(),
+      ),
+    });
+  } catch (error) {
+    console.error("Could not refresh weekly reflection stats:", error);
+    renderWeeklyReflectionStats({
+      dateLabel: weekLabel,
+      tasksFocused: "—",
+      focusTimeLabel: "—",
+      tasksCompleted: "—",
+    });
+  }
+}
+
 function initDailyReflectionStatsWidget() {
   const dateEl = document.getElementById("dailyReflectionDate");
   if (!dateEl) return;
@@ -1028,6 +1171,21 @@ function initDailyReflectionStatsWidget() {
   });
 
   window.addEventListener("focus", refreshDailyReflectionStats);
+}
+
+function initWeeklyReflectionStatsWidget() {
+  const dateEl = document.getElementById("weeklyReflectionDate");
+  if (!dateEl) return;
+
+  refreshWeeklyReflectionStats();
+
+  window.setInterval(refreshWeeklyReflectionStats, 60000);
+
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) refreshWeeklyReflectionStats();
+  });
+
+  window.addEventListener("focus", refreshWeeklyReflectionStats);
 }
 
 async function initDailyEmailSettings() {
@@ -1490,6 +1648,7 @@ document.addEventListener("DOMContentLoaded", () => {
   bindDashboardTaskFilterTabs();
   initDailyEmailSettings();
   initDailyReflectionStatsWidget();
+  initWeeklyReflectionStatsWidget();
 
   checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
   initFocusMode();


### PR DESCRIPTION
### Motivation
- Provide a Weekly Reflection view that mirrors the Daily Reflection so users can see aggregated metrics across the current week. 
- Use the same event data powering daily stats to compute week-level totals so the weekly view stays accurate as the week progresses. 
- Display the week as "Monday ... - Sunday ..." to make the weekly window explicit.

### Description
- Added a Weekly Reflection section to `public/dashboard.html` with IDs `weeklyReflectionDate`, `weeklyReflectionTasksFocused`, `weeklyReflectionFocusTime`, and `weeklyReflectionTasksCompleted` to match the daily widget layout. 
- Implemented `getCurrentWeekDateRangeIso()` to compute the week window (Monday 00:00 → next Monday 00:00) and format the visible label as Monday–Sunday. 
- Implemented `getCompletedTaskCountInRange()`, `renderWeeklyReflectionStats()` and `refreshWeeklyReflectionStats()` in `public/js/main.js` to fetch `/focus-sessions` and `/tasks`, aggregate distinct focused tasks, sum focus time via `computeSessionDurationMs()`, and count tasks completed within the week range. 
- Wired `initWeeklyReflectionStatsWidget()` into the dashboard startup so the weekly metrics refresh on load and then automatically every minute and on visibility/focus events.

### Testing
- Ran `node --check public/js/main.js` to validate the added JavaScript syntax and it succeeded. 
- No automated unit tests exist for the UI in this repo, so runtime behavior was validated by static checks only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a0ed5bcc8326b1d7410df2b20446)