### PR TITLE
Remove duplicate rate limiter import to fix serverless crash

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,7 +13,6 @@ const FocusSession = require("./config/models/focusSession"); // FocusSession mo
 const rateLimit = require("express-rate-limit");
 const FeedbackReport = require("./config/models/feedbackReport"); // Feedback report model for durable rate limiting
 const InboundEmail = require("./config/models/inboundEmail"); // Resend inbound email storage
-const rateLimit = require("express-rate-limit"); // Rate limiting middleware
 const csrf = require("lusca").csrf; // CSRF protection middleware
 const MongoStore = require("connect-mongo").default; // Store sessions in MongoDB
 


### PR DESCRIPTION
### Motivation
- A duplicate `const rateLimit = require("express-rate-limit")` declaration in `server.js` can trigger a parse/runtime error (`Identifier 'rateLimit' has already been declared`) that causes serverless functions to fail at startup.

### Description
- Remove the duplicate `const rateLimit = require("express-rate-limit")` line from `server.js` so the module is imported only once.

### Testing
- Ran `node --check server.js` to validate syntax and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0892c7fc8326ba79ed7b4851d809)