### PR TITLE
Add picture-in-picture mode for focus timer widget

### DIFF
--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -56,9 +56,14 @@
 
 .focus-session-heading {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: flex-end;
   gap: 0.5rem;
+}
+
+.focus-session-heading .focus-phase-title {
+  align-self: stretch;
+  text-align: center;
 }
 
 .focus-pip-toggle {
@@ -74,12 +79,12 @@
   cursor: pointer;
 }
 
-.focus-pip-toggle:disabled {
+.focus-pip-toggle[aria-disabled="true"] {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.focus-pip-toggle:hover:not(:disabled) {
+.focus-pip-toggle:hover {
   background: rgba(255, 255, 255, 0.85);
 }
 

--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -107,6 +107,15 @@
   color: #fff !important;
 }
 
+#focusPiPBtn {
+  background: linear-gradient(180deg, #6f81f0 0%, #4b5ecf 100%);
+  color: #fff !important;
+}
+
+#focusPiPBtn:hover:not(:disabled) {
+  background: linear-gradient(180deg, #8191f5 0%, #5a6ce0 100%);
+}
+
 .focus-timer {
   min-width: 4.2ch;
   font-family: "Quantico", serif;

--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -83,6 +83,11 @@
   background: rgba(255, 255, 255, 0.85);
 }
 
+.focus-pip-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
 #focus-mode-widget .focus-status {
   margin: 0;
   font-size: 0.95rem;

--- a/public/css/focus-page.css
+++ b/public/css/focus-page.css
@@ -54,6 +54,35 @@
   color: #5d4037;
 }
 
+.focus-session-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.focus-pip-toggle {
+  border: 1px solid rgba(93, 64, 55, 0.35);
+  background: rgba(255, 255, 255, 0.55);
+  color: #5d4037;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.focus-pip-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.focus-pip-toggle:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.85);
+}
+
 #focus-mode-widget .focus-status {
   margin: 0;
   font-size: 0.95rem;
@@ -105,15 +134,6 @@
 
 #focusStopBtn {
   color: #fff !important;
-}
-
-#focusPiPBtn {
-  background: linear-gradient(180deg, #6f81f0 0%, #4b5ecf 100%);
-  color: #fff !important;
-}
-
-#focusPiPBtn:hover:not(:disabled) {
-  background: linear-gradient(180deg, #8191f5 0%, #5a6ce0 100%);
 }
 
 .focus-timer {

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -93,7 +93,23 @@
 
         <div class="focus-column focus-column-middle">
           <article class="sticky-note white tape focus-card focus-session-card">
-            <h2 class="focus-phase-title">Concentration Phase</h2>
+            <div class="focus-session-heading">
+              <h2 class="focus-phase-title">Concentration Phase</h2>
+              <button
+                id="focusPiPToggleBtn"
+                class="focus-pip-toggle"
+                type="button"
+                aria-label="Pop out focus timer"
+                title="Pop out timer"
+                disabled
+              >
+                <i
+                  id="focusPiPIcon"
+                  class="fa-solid fa-up-right-and-down-left-from-center"
+                  aria-hidden="true"
+                ></i>
+              </button>
+            </div>
             <p id="focus-status" class="focus-status">
               Pick a task and start a focus session.
             </p>
@@ -105,15 +121,6 @@
             <div class="focus-controls">
               <button id="focusStartBtn" class="paper-button" type="button">
                 Start
-              </button>
-              <button
-                id="focusPiPBtn"
-                class="paper-button"
-                type="button"
-                disabled
-                aria-label="Pop out focus timer into picture in picture"
-              >
-                Pop Out Timer
               </button>
               <button
                 id="focusStopBtn"

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -107,6 +107,15 @@
                 Start
               </button>
               <button
+                id="focusPiPBtn"
+                class="paper-button"
+                type="button"
+                disabled
+                aria-label="Pop out focus timer into picture in picture"
+              >
+                Pop Out Timer
+              </button>
+              <button
                 id="focusStopBtn"
                 class="paper-button"
                 type="button"

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -94,15 +94,13 @@
         <div class="focus-column focus-column-middle">
           <article class="sticky-note white tape focus-card focus-session-card">
             <div class="focus-session-heading">
-              <h2 class="focus-phase-title">Concentration Phase</h2>
               <button
                 id="focusPiPToggleBtn"
                 class="focus-pip-toggle"
                 type="button"
                 aria-label="Pop out focus timer"
                 title="Pop out timer"
-                hidden
-                disabled
+                aria-disabled="true"
               >
                 <span
                   id="focusPiPIcon"
@@ -110,6 +108,7 @@
                   aria-hidden="true"
                 ></span>
               </button>
+              <h2 class="focus-phase-title">Concentration Phase</h2>
             </div>
             <p id="focus-status" class="focus-status">
               Pick a task and start a focus session.

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -101,15 +101,14 @@
                 type="button"
                 aria-label="Pop out focus timer"
                 title="Pop out timer"
+                hidden
                 disabled
               >
                 <span
                   id="focusPiPIcon"
-                  class="focus-pip-icon"
+                  class="focus-pip-icon fa-solid fa-up-right-from-square"
                   aria-hidden="true"
-                >
-                  ⤢
-                </span>
+                ></span>
               </button>
             </div>
             <p id="focus-status" class="focus-status">

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -103,11 +103,13 @@
                 title="Pop out timer"
                 disabled
               >
-                <i
+                <span
                   id="focusPiPIcon"
-                  class="fa-solid fa-picture-in-picture"
+                  class="focus-pip-icon"
                   aria-hidden="true"
-                ></i>
+                >
+                  ⤢
+                </span>
               </button>
             </div>
             <p id="focus-status" class="focus-status">

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -105,7 +105,7 @@
               >
                 <i
                   id="focusPiPIcon"
-                  class="fa-solid fa-up-right-and-down-left-from-center"
+                  class="fa-solid fa-picture-in-picture"
                   aria-hidden="true"
                 ></i>
               </button>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -72,6 +72,8 @@ const focusState = {
   sessionId: null,
   startedAt: null,
   timerIntervalId: null,
+  timerEl: null,
+  sessionCardEl: null,
   pipWindow: null,
   isInPiP: false,
   pipOriginalParent: null,
@@ -139,8 +141,48 @@ function formatFocusDuration(totalSeconds) {
   return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 }
 
+function getFocusTimerEl() {
+  if (focusState.timerEl && focusState.timerEl.isConnected) {
+    return focusState.timerEl;
+  }
+
+  const fromMainDoc = document.getElementById("focusTimer");
+  if (fromMainDoc) {
+    focusState.timerEl = fromMainDoc;
+    return fromMainDoc;
+  }
+
+  const fromPiPDoc = focusState.pipWindow?.document?.getElementById("focusTimer");
+  if (fromPiPDoc) {
+    focusState.timerEl = fromPiPDoc;
+    return fromPiPDoc;
+  }
+
+  return null;
+}
+
+function getFocusSessionCardEl() {
+  if (focusState.sessionCardEl && focusState.sessionCardEl.isConnected) {
+    return focusState.sessionCardEl;
+  }
+
+  const fromMainDoc = document.querySelector(".focus-session-card");
+  if (fromMainDoc) {
+    focusState.sessionCardEl = fromMainDoc;
+    return fromMainDoc;
+  }
+
+  const fromPiPDoc = focusState.pipWindow?.document?.querySelector(".focus-session-card");
+  if (fromPiPDoc) {
+    focusState.sessionCardEl = fromPiPDoc;
+    return fromPiPDoc;
+  }
+
+  return null;
+}
+
 function renderFocusTimer() {
-  const timerEl = document.getElementById("focusTimer");
+  const timerEl = getFocusTimerEl();
   if (!timerEl) return;
 
   if (!focusState.startedAt) {
@@ -183,11 +225,11 @@ function updateFocusPiPToggleButton() {
   if (focusState.isInPiP) {
     toggleBtn.setAttribute("aria-label", "Pop timer back into page");
     toggleBtn.setAttribute("title", "Pop in timer");
-    iconEl.className = "fa-solid fa-down-left-and-up-right-to-center";
+    iconEl.className = "fa-solid fa-picture-in-picture";
   } else {
     toggleBtn.setAttribute("aria-label", "Pop out focus timer");
     toggleBtn.setAttribute("title", "Pop out timer");
-    iconEl.className = "fa-solid fa-up-right-and-down-left-from-center";
+    iconEl.className = "fa-solid fa-picture-in-picture";
   }
 }
 
@@ -203,7 +245,7 @@ function copyStylesToPiPWindow(pipWindow) {
 }
 
 function returnFocusWidgetToMainPage() {
-  const sessionCard = document.querySelector(".focus-session-card");
+  const sessionCard = getFocusSessionCardEl();
   if (!sessionCard || !focusState.pipOriginalParent) return;
 
   if (
@@ -237,7 +279,7 @@ async function openFocusWidgetInPiP() {
 
   if (focusState.isInPiP) return;
 
-  const sessionCard = document.querySelector(".focus-session-card");
+  const sessionCard = getFocusSessionCardEl();
   if (!sessionCard) return;
 
   focusState.pipOriginalParent = sessionCard.parentNode;
@@ -885,6 +927,8 @@ async function initFocusMode() {
   const completeBtn = document.getElementById("focusCompleteBtn");
   const statusEl = document.getElementById("focus-status");
   if (!selectEl || !startBtn || !pipToggleBtn || !stopBtn || !completeBtn || !statusEl) return;
+  focusState.timerEl = document.getElementById("focusTimer");
+  focusState.sessionCardEl = document.querySelector(".focus-session-card");
 
   bindFocusFilterTabs();
   setFocusQuoteText("", { typewriter: false });

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -226,11 +226,11 @@ function updateFocusPiPToggleButton() {
   if (focusState.isInPiP) {
     toggleBtn.setAttribute("aria-label", "Pop timer back into page");
     toggleBtn.setAttribute("title", "Pop in timer");
-    iconEl.textContent = "⤡";
+    iconEl.className = "focus-pip-icon fa-solid fa-down-left-and-up-right-to-center";
   } else {
     toggleBtn.setAttribute("aria-label", "Pop out focus timer");
     toggleBtn.setAttribute("title", "Pop out timer");
-    iconEl.textContent = "⤢";
+    iconEl.className = "focus-pip-icon fa-solid fa-up-right-from-square";
   }
 }
 
@@ -299,6 +299,8 @@ async function openFocusWidgetInPiP() {
 
     focusState.pipWindow = pipWindow;
     focusState.isInPiP = true;
+    const startBtn = document.getElementById("focusStartBtn");
+    if (startBtn) startBtn.hidden = true;
     updateFocusPiPToggleButton();
     updateFocusModeControls({
       running: Boolean(focusState.taskId),

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -218,7 +218,7 @@ function updateFocusPiPToggleButton() {
   const iconEl = document.getElementById("focusPiPIcon");
   if (!toggleBtn || !iconEl) return;
 
-  const isRunning = Boolean(focusState.taskId);
+  const isRunning = Boolean(focusState.taskId && focusState.startedAt);
   const supported = isDocumentPictureInPictureSupported();
   toggleBtn.hidden = !isRunning;
   toggleBtn.disabled = !isRunning || !supported;
@@ -243,6 +243,10 @@ function copyStylesToPiPWindow(pipWindow) {
     const clone = linkEl.cloneNode(true);
     head.appendChild(clone);
   });
+
+  const pipStyle = pipWindow.document.createElement("style");
+  pipStyle.textContent = "#focusStartBtn { display: none !important; }";
+  head.appendChild(pipStyle);
 }
 
 function returnFocusWidgetToMainPage() {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -220,7 +220,10 @@ function updateFocusPiPToggleButton() {
 
   const isRunning = Boolean(focusState.taskId && focusState.startedAt);
   const supported = isDocumentPictureInPictureSupported();
-  toggleBtn.disabled = !isRunning || !supported;
+  toggleBtn.setAttribute(
+    "aria-disabled",
+    !isRunning || !supported ? "true" : "false",
+  );
 
   if (focusState.isInPiP) {
     toggleBtn.setAttribute("aria-label", "Pop timer back into page");
@@ -274,7 +277,8 @@ function returnFocusWidgetToMainPage() {
 async function openFocusWidgetInPiP() {
   if (!isDocumentPictureInPictureSupported()) {
     Toast.show({
-      message: "Picture-in-picture is not supported in this browser yet.",
+      message:
+        "Oh no! You can't use that here. Try on a different browser or device.",
       type: "error",
       duration: 3200,
     });
@@ -549,9 +553,6 @@ function updateFocusModeControls({ running, hasTask } = {}) {
   if (startBtn) {
     startBtn.hidden = Boolean(running) || focusState.isInPiP;
     startBtn.disabled = Boolean(running);
-  }
-  if (pipToggleBtn) {
-    pipToggleBtn.hidden = !Boolean(running);
   }
   updateFocusPiPToggleButton();
   if (stopBtn) {
@@ -937,8 +938,7 @@ async function initFocusMode() {
   const completeBtn = document.getElementById("focusCompleteBtn");
   const statusEl = document.getElementById("focus-status");
   if (!selectEl || !startBtn || !pipToggleBtn || !stopBtn || !completeBtn || !statusEl) return;
-  pipToggleBtn.hidden = true;
-  pipToggleBtn.disabled = true;
+  pipToggleBtn.setAttribute("aria-disabled", "true");
   focusState.timerEl = document.getElementById("focusTimer");
   focusState.sessionCardEl = document.querySelector(".focus-session-card");
 
@@ -1035,7 +1035,25 @@ async function initFocusMode() {
   });
 
   pipToggleBtn.addEventListener("click", async () => {
-    if (!focusState.taskId) return;
+    if (!focusState.taskId || !focusState.startedAt) {
+      Toast.show({
+        message: "You should probably start focusing first.",
+        type: "error",
+        duration: 2600,
+      });
+      return;
+    }
+
+    if (!isDocumentPictureInPictureSupported()) {
+      Toast.show({
+        message:
+          "Oh no! You can't use that here. Try on a different browser or device.",
+        type: "error",
+        duration: 3200,
+      });
+      return;
+    }
+
     if (focusState.isInPiP) {
       closeFocusWidgetPiP();
       return;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -72,6 +72,10 @@ const focusState = {
   sessionId: null,
   startedAt: null,
   timerIntervalId: null,
+  pipWindow: null,
+  isInPiP: false,
+  pipOriginalParent: null,
+  pipOriginalNextSibling: null,
   quoteTimeoutIds: [],
   quoteTypingIntervalId: null,
   currentQuoteToken: 0,
@@ -160,6 +164,107 @@ function stopFocusTimer() {
   if (focusState.timerIntervalId) {
     window.clearInterval(focusState.timerIntervalId);
     focusState.timerIntervalId = null;
+  }
+}
+
+function isDocumentPictureInPictureSupported() {
+  return Boolean(window.documentPictureInPicture?.requestWindow);
+}
+
+function copyStylesToPiPWindow(pipWindow) {
+  if (!pipWindow?.document) return;
+  const head = pipWindow.document.head;
+  if (!head) return;
+
+  document.querySelectorAll('link[rel="stylesheet"]').forEach((linkEl) => {
+    const clone = linkEl.cloneNode(true);
+    head.appendChild(clone);
+  });
+}
+
+function returnFocusWidgetToMainPage() {
+  const sessionCard = document.querySelector(".focus-session-card");
+  if (!sessionCard || !focusState.pipOriginalParent) return;
+
+  if (
+    focusState.pipOriginalNextSibling &&
+    focusState.pipOriginalNextSibling.parentNode === focusState.pipOriginalParent
+  ) {
+    focusState.pipOriginalParent.insertBefore(
+      sessionCard,
+      focusState.pipOriginalNextSibling,
+    );
+  } else {
+    focusState.pipOriginalParent.appendChild(sessionCard);
+  }
+
+  focusState.isInPiP = false;
+  focusState.pipWindow = null;
+  focusState.pipOriginalParent = null;
+  focusState.pipOriginalNextSibling = null;
+}
+
+async function openFocusWidgetInPiP() {
+  if (!isDocumentPictureInPictureSupported()) {
+    Toast.show({
+      message: "Picture-in-picture is not supported in this browser yet.",
+      type: "error",
+      duration: 3200,
+    });
+    return;
+  }
+
+  if (focusState.isInPiP) return;
+
+  const sessionCard = document.querySelector(".focus-session-card");
+  if (!sessionCard) return;
+
+  focusState.pipOriginalParent = sessionCard.parentNode;
+  focusState.pipOriginalNextSibling = sessionCard.nextSibling;
+
+  try {
+    const pipWindow = await window.documentPictureInPicture.requestWindow({
+      width: 440,
+      height: 360,
+    });
+    copyStylesToPiPWindow(pipWindow);
+    pipWindow.document.body.className = "pip-focus-window";
+    pipWindow.document.body.style.margin = "0";
+    pipWindow.document.body.style.padding = "12px";
+    pipWindow.document.body.appendChild(sessionCard);
+
+    focusState.pipWindow = pipWindow;
+    focusState.isInPiP = true;
+    updateFocusModeControls({
+      running: Boolean(focusState.taskId),
+      hasTask: Boolean(document.getElementById("focusTaskSelect")?.value),
+    });
+
+    pipWindow.addEventListener("pagehide", () => {
+      returnFocusWidgetToMainPage();
+      updateFocusModeControls({
+        running: Boolean(focusState.taskId),
+        hasTask: Boolean(document.getElementById("focusTaskSelect")?.value),
+      });
+    });
+  } catch (error) {
+    focusState.pipOriginalParent = null;
+    focusState.pipOriginalNextSibling = null;
+    console.error("Could not open focus widget in picture-in-picture:", error);
+    Toast.show({
+      message: "Could not open picture-in-picture right now.",
+      type: "error",
+      duration: 3000,
+    });
+  }
+}
+
+function closeFocusWidgetPiP() {
+  if (!focusState.isInPiP) return;
+  if (focusState.pipWindow && !focusState.pipWindow.closed) {
+    focusState.pipWindow.close();
+  } else {
+    returnFocusWidgetToMainPage();
   }
 }
 
@@ -354,6 +459,7 @@ function updateFocusModeControls({ running, hasTask } = {}) {
   const selectEl = document.getElementById("focusTaskSelect");
   const taskListEl = document.getElementById("focusTaskList");
   const startBtn = document.getElementById("focusStartBtn");
+  const pipBtn = document.getElementById("focusPiPBtn");
   const stopBtn = document.getElementById("focusStopBtn");
   const completeBtn = document.getElementById("focusCompleteBtn");
   if (selectEl) selectEl.disabled = running;
@@ -372,6 +478,12 @@ function updateFocusModeControls({ running, hasTask } = {}) {
   if (startBtn) {
     startBtn.hidden = Boolean(running);
     startBtn.disabled = Boolean(running);
+  }
+  if (pipBtn) {
+    pipBtn.hidden = !Boolean(running);
+    pipBtn.disabled =
+      !Boolean(running) || !isDocumentPictureInPictureSupported();
+    pipBtn.textContent = focusState.isInPiP ? "In Picture-in-Picture" : "Pop Out Timer";
   }
   if (stopBtn) {
     stopBtn.hidden = !Boolean(running);
@@ -680,6 +792,7 @@ async function stopFocusSession(reason = "manual_stop") {
   }
 
   stopFocusTimer();
+  closeFocusWidgetPiP();
   clearFocusQuoteTimers();
   focusState.taskId = null;
   focusState.sessionId = null;
@@ -750,10 +863,11 @@ async function completeTask(taskId) {
 async function initFocusMode() {
   const selectEl = document.getElementById("focusTaskSelect");
   const startBtn = document.getElementById("focusStartBtn");
+  const pipBtn = document.getElementById("focusPiPBtn");
   const stopBtn = document.getElementById("focusStopBtn");
   const completeBtn = document.getElementById("focusCompleteBtn");
   const statusEl = document.getElementById("focus-status");
-  if (!selectEl || !startBtn || !stopBtn || !completeBtn || !statusEl) return;
+  if (!selectEl || !startBtn || !pipBtn || !stopBtn || !completeBtn || !statusEl) return;
 
   bindFocusFilterTabs();
   setFocusQuoteText("", { typewriter: false });
@@ -844,6 +958,11 @@ async function initFocusMode() {
 
   stopBtn.addEventListener("click", async () => {
     await stopFocusSession("manual_stop");
+  });
+
+  pipBtn.addEventListener("click", async () => {
+    if (!focusState.taskId || focusState.isInPiP) return;
+    await openFocusWidgetInPiP();
   });
 
   completeBtn.addEventListener("click", async () => {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -934,6 +934,8 @@ async function initFocusMode() {
   const completeBtn = document.getElementById("focusCompleteBtn");
   const statusEl = document.getElementById("focus-status");
   if (!selectEl || !startBtn || !pipToggleBtn || !stopBtn || !completeBtn || !statusEl) return;
+  pipToggleBtn.hidden = true;
+  pipToggleBtn.disabled = true;
   focusState.timerEl = document.getElementById("focusTimer");
   focusState.sessionCardEl = document.querySelector(".focus-session-card");
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -220,7 +220,6 @@ function updateFocusPiPToggleButton() {
 
   const isRunning = Boolean(focusState.taskId && focusState.startedAt);
   const supported = isDocumentPictureInPictureSupported();
-  toggleBtn.hidden = !isRunning;
   toggleBtn.disabled = !isRunning || !supported;
 
   if (focusState.isInPiP) {
@@ -531,6 +530,7 @@ function updateFocusModeControls({ running, hasTask } = {}) {
   const selectEl = document.getElementById("focusTaskSelect");
   const taskListEl = document.getElementById("focusTaskList");
   const startBtn = document.getElementById("focusStartBtn");
+  const pipToggleBtn = document.getElementById("focusPiPToggleBtn");
   const stopBtn = document.getElementById("focusStopBtn");
   const completeBtn = document.getElementById("focusCompleteBtn");
   if (selectEl) selectEl.disabled = running;
@@ -549,6 +549,9 @@ function updateFocusModeControls({ running, hasTask } = {}) {
   if (startBtn) {
     startBtn.hidden = Boolean(running) || focusState.isInPiP;
     startBtn.disabled = Boolean(running);
+  }
+  if (pipToggleBtn) {
+    pipToggleBtn.hidden = !Boolean(running);
   }
   updateFocusPiPToggleButton();
   if (stopBtn) {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -171,6 +171,26 @@ function isDocumentPictureInPictureSupported() {
   return Boolean(window.documentPictureInPicture?.requestWindow);
 }
 
+function updateFocusPiPToggleButton() {
+  const toggleBtn = document.getElementById("focusPiPToggleBtn");
+  const iconEl = document.getElementById("focusPiPIcon");
+  if (!toggleBtn || !iconEl) return;
+
+  const isRunning = Boolean(focusState.taskId);
+  const supported = isDocumentPictureInPictureSupported();
+  toggleBtn.disabled = !isRunning || !supported;
+
+  if (focusState.isInPiP) {
+    toggleBtn.setAttribute("aria-label", "Pop timer back into page");
+    toggleBtn.setAttribute("title", "Pop in timer");
+    iconEl.className = "fa-solid fa-down-left-and-up-right-to-center";
+  } else {
+    toggleBtn.setAttribute("aria-label", "Pop out focus timer");
+    toggleBtn.setAttribute("title", "Pop out timer");
+    iconEl.className = "fa-solid fa-up-right-and-down-left-from-center";
+  }
+}
+
 function copyStylesToPiPWindow(pipWindow) {
   if (!pipWindow?.document) return;
   const head = pipWindow.document.head;
@@ -202,6 +222,7 @@ function returnFocusWidgetToMainPage() {
   focusState.pipWindow = null;
   focusState.pipOriginalParent = null;
   focusState.pipOriginalNextSibling = null;
+  updateFocusPiPToggleButton();
 }
 
 async function openFocusWidgetInPiP() {
@@ -235,6 +256,7 @@ async function openFocusWidgetInPiP() {
 
     focusState.pipWindow = pipWindow;
     focusState.isInPiP = true;
+    updateFocusPiPToggleButton();
     updateFocusModeControls({
       running: Boolean(focusState.taskId),
       hasTask: Boolean(document.getElementById("focusTaskSelect")?.value),
@@ -250,6 +272,7 @@ async function openFocusWidgetInPiP() {
   } catch (error) {
     focusState.pipOriginalParent = null;
     focusState.pipOriginalNextSibling = null;
+    updateFocusPiPToggleButton();
     console.error("Could not open focus widget in picture-in-picture:", error);
     Toast.show({
       message: "Could not open picture-in-picture right now.",
@@ -459,7 +482,6 @@ function updateFocusModeControls({ running, hasTask } = {}) {
   const selectEl = document.getElementById("focusTaskSelect");
   const taskListEl = document.getElementById("focusTaskList");
   const startBtn = document.getElementById("focusStartBtn");
-  const pipBtn = document.getElementById("focusPiPBtn");
   const stopBtn = document.getElementById("focusStopBtn");
   const completeBtn = document.getElementById("focusCompleteBtn");
   if (selectEl) selectEl.disabled = running;
@@ -479,12 +501,7 @@ function updateFocusModeControls({ running, hasTask } = {}) {
     startBtn.hidden = Boolean(running);
     startBtn.disabled = Boolean(running);
   }
-  if (pipBtn) {
-    pipBtn.hidden = !Boolean(running);
-    pipBtn.disabled =
-      !Boolean(running) || !isDocumentPictureInPictureSupported();
-    pipBtn.textContent = focusState.isInPiP ? "In Picture-in-Picture" : "Pop Out Timer";
-  }
+  updateFocusPiPToggleButton();
   if (stopBtn) {
     stopBtn.hidden = !Boolean(running);
     stopBtn.disabled = !Boolean(running);
@@ -863,14 +880,15 @@ async function completeTask(taskId) {
 async function initFocusMode() {
   const selectEl = document.getElementById("focusTaskSelect");
   const startBtn = document.getElementById("focusStartBtn");
-  const pipBtn = document.getElementById("focusPiPBtn");
+  const pipToggleBtn = document.getElementById("focusPiPToggleBtn");
   const stopBtn = document.getElementById("focusStopBtn");
   const completeBtn = document.getElementById("focusCompleteBtn");
   const statusEl = document.getElementById("focus-status");
-  if (!selectEl || !startBtn || !pipBtn || !stopBtn || !completeBtn || !statusEl) return;
+  if (!selectEl || !startBtn || !pipToggleBtn || !stopBtn || !completeBtn || !statusEl) return;
 
   bindFocusFilterTabs();
   setFocusQuoteText("", { typewriter: false });
+  updateFocusPiPToggleButton();
 
   try {
     await loadFocusTasks();
@@ -960,8 +978,12 @@ async function initFocusMode() {
     await stopFocusSession("manual_stop");
   });
 
-  pipBtn.addEventListener("click", async () => {
-    if (!focusState.taskId || focusState.isInPiP) return;
+  pipToggleBtn.addEventListener("click", async () => {
+    if (!focusState.taskId) return;
+    if (focusState.isInPiP) {
+      closeFocusWidgetPiP();
+      return;
+    }
     await openFocusWidgetInPiP();
   });
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -220,16 +220,17 @@ function updateFocusPiPToggleButton() {
 
   const isRunning = Boolean(focusState.taskId);
   const supported = isDocumentPictureInPictureSupported();
+  toggleBtn.hidden = !isRunning;
   toggleBtn.disabled = !isRunning || !supported;
 
   if (focusState.isInPiP) {
     toggleBtn.setAttribute("aria-label", "Pop timer back into page");
     toggleBtn.setAttribute("title", "Pop in timer");
-    iconEl.className = "fa-solid fa-picture-in-picture";
+    iconEl.textContent = "⤡";
   } else {
     toggleBtn.setAttribute("aria-label", "Pop out focus timer");
     toggleBtn.setAttribute("title", "Pop out timer");
-    iconEl.className = "fa-solid fa-picture-in-picture";
+    iconEl.textContent = "⤢";
   }
 }
 
@@ -540,7 +541,7 @@ function updateFocusModeControls({ running, hasTask } = {}) {
   updateFocusFilterTabs(focusState.filter, { running: Boolean(running) });
 
   if (startBtn) {
-    startBtn.hidden = Boolean(running);
+    startBtn.hidden = Boolean(running) || focusState.isInPiP;
     startBtn.disabled = Boolean(running);
   }
   updateFocusPiPToggleButton();


### PR DESCRIPTION
### Motivation
- Allow the focus timer to remain visible above other windows so users can keep tracking their session while working in other apps or browser tabs.
- Ensure the timer returns to the main focus page and stops showing on the main page when the PiP window is closed or the session stops.

### Description
- Add a new `Pop Out Timer` control to the focus session controls in `public/focus-page.html` and style it in `public/css/focus-page.css` so it matches the existing control set.
- Implement PiP behavior in `public/js/main.js` by adding `focusState` fields (`pipWindow`, `isInPiP`, `pipOriginalParent`, `pipOriginalNextSibling`) and functions `isDocumentPictureInPictureSupported()`, `openFocusWidgetInPiP()`, `closeFocusWidgetPiP()`, `returnFocusWidgetToMainPage()`, and `copyStylesToPiPWindow()` to move the `.focus-session-card` node into a document Picture-in-Picture window and restore it later.
- Hide the timer on the main page while in PiP by moving the existing DOM node into the PiP window and restore it automatically when the PiP window is closed or when the session is stopped.
- Update control state handling so the PiP button is only visible/enabled while a session is running and only when the browser supports document PiP, and update its label to reflect the PiP state.

### Testing
- Ran `node --check public/js/main.js` to validate the added JavaScript syntax and it succeeded.
- No automated browser/UI tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd83bc416883268e698ed994d01067)