### PR TITLE
Add Account Profile button to navbar status area

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -72,10 +72,11 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
-            <span class="nav-profile-pin" aria-hidden="true">
-              <i class="fa-solid fa-thumbtack"></i>
-            </span>
+        <a
+            href="/profile-page.html"
+            class="nav-profile-button sticky-note thumbtack"
+            aria-label="Open profile"
+          >
             <i class="fa-solid fa-user" aria-hidden="true"></i>
             <span class="sr-only">Profile</span>
           </a>

--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -72,6 +72,7 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
+        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -72,7 +72,13 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
+        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
+            <span class="nav-profile-pin" aria-hidden="true">
+              <i class="fa-solid fa-thumbtack"></i>
+            </span>
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            <span class="sr-only">Profile</span>
+          </a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/css/navbar.css
+++ b/public/css/navbar.css
@@ -158,27 +158,45 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 7px 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(198, 83, 78, 0.35);
-  background: rgba(255, 255, 255, 0.8);
+  width: 44px;
+  height: 44px;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  background: linear-gradient(155deg, #ffe98c 0%, #f7d96b 100%);
   color: #5b3a34;
   text-decoration: none;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  font-size: 16px;
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  transform: rotate(1.5deg);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    filter 0.2s ease;
+  position: relative;
 }
 
 .nav-profile-button:hover {
-  background: #c6534e;
-  color: #fff;
+  transform: rotate(0deg) translateY(-1px);
+  box-shadow:
+    0 4px 8px rgba(0, 0, 0, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  filter: saturate(1.06);
 }
 
 .nav-profile-button:focus-visible {
   outline: 2px solid #c6534e;
   outline-offset: 2px;
+}
+
+.nav-profile-pin {
+  position: absolute;
+  top: -8px;
+  right: -6px;
+  font-size: 13px;
+  color: #c6534e;
+  transform: rotate(14deg);
 }
 
 #nav-backdrop {
@@ -246,8 +264,9 @@
   }
 
   .nav-profile-button {
-    padding: 6px 10px;
-    font-size: 11px;
+    width: 40px;
+    height: 40px;
+    font-size: 14px;
   }
 
   #nav-drawer {
@@ -305,7 +324,8 @@
   }
 
   .nav-profile-button {
-    padding: 6px 9px;
-    font-size: 10px;
+    width: 36px;
+    height: 36px;
+    font-size: 13px;
   }
 }

--- a/public/css/navbar.css
+++ b/public/css/navbar.css
@@ -106,6 +106,9 @@
 }
 
 .nav-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   margin-left: auto;
   min-width: 0;
 }
@@ -151,6 +154,33 @@
   color: #5b3a34;
 }
 
+.nav-profile-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(198, 83, 78, 0.35);
+  background: rgba(255, 255, 255, 0.8);
+  color: #5b3a34;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.nav-profile-button:hover {
+  background: #c6534e;
+  color: #fff;
+}
+
+.nav-profile-button:focus-visible {
+  outline: 2px solid #c6534e;
+  outline-offset: 2px;
+}
+
 #nav-backdrop {
   position: fixed;
   inset: 0;
@@ -186,6 +216,7 @@
   .nav-right {
     flex: 1 1 auto;
     min-width: 0;
+    gap: 8px;
   }
 
   .nav-status {
@@ -212,6 +243,11 @@
     text-overflow: clip;
     word-break: break-word;
     line-height: 1.2;
+  }
+
+  .nav-profile-button {
+    padding: 6px 10px;
+    font-size: 11px;
   }
 
   #nav-drawer {
@@ -266,5 +302,10 @@
 
   .nav-welcome {
     max-width: min(30ch, 58vw);
+  }
+
+  .nav-profile-button {
+    padding: 6px 9px;
+    font-size: 10px;
   }
 }

--- a/public/css/navbar.css
+++ b/public/css/navbar.css
@@ -155,48 +155,33 @@
 }
 
 .nav-profile-button {
+  --note-color: #fff9e1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.14);
-  background: linear-gradient(155deg, #ffe98c 0%, #f7d96b 100%);
+  min-width: 44px;
+  padding: 0;
+  border-radius: 2px;
   color: #5b3a34;
   text-decoration: none;
+  font-family: var(--font-main);
   font-size: 16px;
-  box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.4);
-  transform: rotate(1.5deg);
+  line-height: 1;
+  transform: rotate(-1.5deg);
   transition:
     transform 0.2s ease,
-    box-shadow 0.2s ease,
-    filter 0.2s ease;
-  position: relative;
+    box-shadow 0.2s ease;
 }
 
 .nav-profile-button:hover {
-  transform: rotate(0deg) translateY(-1px);
-  box-shadow:
-    0 4px 8px rgba(0, 0, 0, 0.16),
-    inset 0 1px 0 rgba(255, 255, 255, 0.45);
-  filter: saturate(1.06);
+  transform: rotate(0.5deg) translateY(-1px);
 }
 
 .nav-profile-button:focus-visible {
   outline: 2px solid #c6534e;
   outline-offset: 2px;
-}
-
-.nav-profile-pin {
-  position: absolute;
-  top: -8px;
-  right: -6px;
-  font-size: 13px;
-  color: #c6534e;
-  transform: rotate(14deg);
 }
 
 #nav-backdrop {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -78,6 +78,7 @@
             </div>
             <span id="authStatus" class="nav-welcome"></span>
           </div>
+          <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
         </div>
       </nav>
       <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -78,10 +78,11 @@
             </div>
             <span id="authStatus" class="nav-welcome"></span>
           </div>
-          <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
-            <span class="nav-profile-pin" aria-hidden="true">
-              <i class="fa-solid fa-thumbtack"></i>
-            </span>
+          <a
+            href="/profile-page.html"
+            class="nav-profile-button sticky-note thumbtack"
+            aria-label="Open profile"
+          >
             <i class="fa-solid fa-user" aria-hidden="true"></i>
             <span class="sr-only">Profile</span>
           </a>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -78,7 +78,13 @@
             </div>
             <span id="authStatus" class="nav-welcome"></span>
           </div>
-          <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
+          <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
+            <span class="nav-profile-pin" aria-hidden="true">
+              <i class="fa-solid fa-thumbtack"></i>
+            </span>
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            <span class="sr-only">Profile</span>
+          </a>
         </div>
       </nav>
       <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -69,7 +69,13 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
+        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
+            <span class="nav-profile-pin" aria-hidden="true">
+              <i class="fa-solid fa-thumbtack"></i>
+            </span>
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            <span class="sr-only">Profile</span>
+          </a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -69,10 +69,11 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
-            <span class="nav-profile-pin" aria-hidden="true">
-              <i class="fa-solid fa-thumbtack"></i>
-            </span>
+        <a
+            href="/profile-page.html"
+            class="nav-profile-button sticky-note thumbtack"
+            aria-label="Open profile"
+          >
             <i class="fa-solid fa-user" aria-hidden="true"></i>
             <span class="sr-only">Profile</span>
           </a>

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -69,6 +69,7 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
+        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -70,10 +70,11 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
-            <span class="nav-profile-pin" aria-hidden="true">
-              <i class="fa-solid fa-thumbtack"></i>
-            </span>
+        <a
+            href="/profile-page.html"
+            class="nav-profile-button sticky-note thumbtack"
+            aria-label="Open profile"
+          >
             <i class="fa-solid fa-user" aria-hidden="true"></i>
             <span class="sr-only">Profile</span>
           </a>

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -70,6 +70,7 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
+        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -70,7 +70,13 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
+        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
+            <span class="nav-profile-pin" aria-hidden="true">
+              <i class="fa-solid fa-thumbtack"></i>
+            </span>
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            <span class="sr-only">Profile</span>
+          </a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -72,10 +72,11 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
-            <span class="nav-profile-pin" aria-hidden="true">
-              <i class="fa-solid fa-thumbtack"></i>
-            </span>
+        <a
+            href="/profile-page.html"
+            class="nav-profile-button sticky-note thumbtack"
+            aria-label="Open profile"
+          >
             <i class="fa-solid fa-user" aria-hidden="true"></i>
             <span class="sr-only">Profile</span>
           </a>

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -72,6 +72,7 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
+        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -72,7 +72,13 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
+        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
+            <span class="nav-profile-pin" aria-hidden="true">
+              <i class="fa-solid fa-thumbtack"></i>
+            </span>
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            <span class="sr-only">Profile</span>
+          </a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -69,7 +69,13 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
+        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
+            <span class="nav-profile-pin" aria-hidden="true">
+              <i class="fa-solid fa-thumbtack"></i>
+            </span>
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            <span class="sr-only">Profile</span>
+          </a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -69,10 +69,11 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
-        <a href="/profile-page.html" class="nav-profile-button" aria-label="Open profile">
-            <span class="nav-profile-pin" aria-hidden="true">
-              <i class="fa-solid fa-thumbtack"></i>
-            </span>
+        <a
+            href="/profile-page.html"
+            class="nav-profile-button sticky-note thumbtack"
+            aria-label="Open profile"
+          >
             <i class="fa-solid fa-user" aria-hidden="true"></i>
             <span class="sr-only">Profile</span>
           </a>

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -69,6 +69,7 @@
           </div>
           <span id="authStatus" class="nav-welcome"></span>
         </div>
+        <a href="/profile-page.html" class="nav-profile-button">Account Profile</a>
       </div>
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>


### PR DESCRIPTION
### Motivation
- Provide a persistent, easily discoverable link to the user's profile by placing an "Account Profile" button to the right of the remaining tasks and welcome status in the navbar.
- Keep the navbar layout consistent and responsive across pages while avoiding JavaScript changes for a simple navigation affordance.

### Description
- Added an account link `<a href="/profile-page.html" class="nav-profile-button">Account Profile</a>` into the navbar status area of the main pages: `public/dashboard.html`, `public/calendar-page.html`, `public/focus-page.html`, `public/feedback-page.html`, `public/settings-page.html`, and `public/profile-page.html`.
- Updated `public/css/navbar.css` to make `.nav-right` a flex container and added `.nav-profile-button` styles including hover and focus states, rounded pill appearance, and typography.
- Added responsive size adjustments for the new button at the tablet (`@media (max-width: 1023px)`) and phone (`@media (max-width: 767px)`) breakpoints.
- No JavaScript changes were required because the feature is a simple anchor link to ` /profile-page.html`.

### Testing
- Ran `git diff --check` to verify there are no whitespace or diff issues and confirmed the updated files were staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8141fb0c8326b93d70336681a9a9)