### PR TITLE
Remove Profile nav item from site and minor navbar CSS formatting change

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -60,7 +60,6 @@
         </li>
         <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
         <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-        <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
         <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
 

--- a/public/css/navbar.css
+++ b/public/css/navbar.css
@@ -267,4 +267,5 @@
   .nav-welcome {
     max-width: min(30ch, 58vw);
   }
+
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -66,7 +66,6 @@
           <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
           <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
           <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-          <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
           <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
         </ul>
 

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -58,7 +58,6 @@
           <a href="/feedback-page.html" class="nav-item active">Feedback</a>
         </li>
         <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-        <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
         <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
       <div class="nav-right">

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -59,7 +59,6 @@
           <a href="/feedback-page.html" class="nav-item">Feedback</a>
         </li>
         <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-        <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
         <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
       <div class="nav-right">

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -58,9 +58,6 @@
         <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
         <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
         <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-        <li>
-          <a href="/profile-page.html" class="nav-item active">Profile</a>
-        </li>
         <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
 

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -58,7 +58,6 @@
         <li>
           <a href="/settings-page.html" class="nav-item active">Settings</a>
         </li>
-        <li><a href="/profile-page.html" class="nav-item">Profile</a></li>
         <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
       <div class="nav-right">


### PR DESCRIPTION
### Motivation
- Remove the Profile navigation entry site-wide to hide/deprecate the profile page from the primary navigation.
- Keep the navigation markup consistent across pages and make a small CSS formatting adjustment in the navbar media query.

### Description
- Removed the `<li>` linking to ` /profile-page.html` from `public/calendar-page.html`, `public/dashboard.html`, `public/feedback-page.html`, `public/focus-page.html`, and `public/settings-page.html`.
- Removed the active Profile list item from `public/profile-page.html` so the Profile link is no longer present or highlighted in the nav.
- Applied a minor formatting change (extra newline) inside the `@media (max-width: 767px)` block in `public/css/navbar.css` which does not alter behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8141fb0c8326b93d70336681a9a9)