### PR TITLE
Profile corkboard: add sidebar with in-page sticky-note panels

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2020,6 +2020,45 @@ body.task-panel-open {
   transform: rotate(-0.4deg);
 }
 
+.profile-content-panel.profile-note-leaving {
+  animation: profile-note-leave 340ms ease-in forwards;
+  pointer-events: none;
+}
+
+.profile-content-panel.profile-note-entering {
+  animation: profile-note-enter 360ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  pointer-events: none;
+}
+
+@keyframes profile-note-leave {
+  0% {
+    transform: translateX(0) translateY(0) rotate(-0.4deg);
+    opacity: 1;
+  }
+  30% {
+    transform: translateX(12px) translateY(-12px) rotate(1.2deg);
+  }
+  100% {
+    transform: translateX(130px) translateY(-18px) rotate(3deg);
+    opacity: 0;
+  }
+}
+
+@keyframes profile-note-enter {
+  0% {
+    transform: translateX(130px) translateY(-18px) rotate(3deg);
+    opacity: 0;
+  }
+  65% {
+    transform: translateX(-8px) translateY(0) rotate(-0.8deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(0) translateY(0) rotate(-0.4deg);
+    opacity: 1;
+  }
+}
+
 .profile-dynamic-content .widget-title {
   margin-bottom: 0.35rem;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1941,6 +1941,104 @@ body.task-panel-open {
   padding-top: 2rem;
 }
 
+.corkboard.profile-board {
+  width: min(1240px, 96vw);
+  height: auto;
+  min-height: 72vh;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: clamp(0.9rem, 2.2vw, 1.5rem);
+  align-items: start;
+  padding: clamp(0.9rem, 1.8vw, 1.4rem);
+}
+
+.profile-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-user-card h2 {
+  margin: 0;
+  color: #2f2f2f;
+  text-decoration: none;
+  font-size: clamp(1.4rem, 2.8vw, 2rem);
+}
+
+.profile-user-subtitle {
+  margin-top: 0.2rem;
+  color: #735a4f;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+}
+
+.profile-side-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.profile-nav-link,
+.profile-logout-btn {
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: "Quantico", sans-serif;
+  font-size: 1.02rem;
+  border-radius: 4px;
+  cursor: pointer;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.22);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.profile-nav-link {
+  background: #fff;
+  color: #272727;
+  padding: 0.85rem 1rem;
+}
+
+.profile-nav-link.is-active {
+  background: #f4eebf;
+  color: #1f1f1f;
+}
+
+.profile-logout-btn {
+  margin-top: 0.25rem;
+  padding: 0.8rem 1rem;
+  background: #d83434;
+  color: #fff;
+  font-weight: 700;
+}
+
+.profile-content-panel {
+  min-height: clamp(520px, 68vh, 860px);
+  padding: clamp(1rem, 2.2vw, 1.8rem) !important;
+  transform: rotate(-0.4deg);
+}
+
+.profile-dynamic-content .widget-title {
+  margin-bottom: 0.35rem;
+}
+
+.profile-dynamic-content p {
+  width: auto;
+  justify-self: flex-start;
+}
+
+@media (max-width: 900px) {
+  .corkboard.profile-board {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-content-panel {
+    min-height: auto;
+  }
+}
+
 .feedback-note {
   width: min(1180px, 94%) !important;
   padding: clamp(1rem, 2vw, 1.4rem) !important;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1946,6 +1946,7 @@ body.task-panel-open {
   height: auto;
   min-height: 72vh;
   margin: 0 auto;
+  overflow: visible;
   display: grid;
   grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
   gap: clamp(0.9rem, 2.2vw, 1.5rem);

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2039,14 +2039,14 @@ body.task-panel-open {
     transform: translateX(12px) translateY(-12px) rotate(1.2deg);
   }
   100% {
-    transform: translateX(130px) translateY(-18px) rotate(3deg);
+    transform: translateX(120vw) translateY(-18px) rotate(3deg);
     opacity: 0;
   }
 }
 
 @keyframes profile-note-enter {
   0% {
-    transform: translateX(130px) translateY(-18px) rotate(3deg);
+    transform: translateX(120vw) translateY(-18px) rotate(3deg);
     opacity: 0;
   }
   65% {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1803,8 +1803,23 @@ function getProfilePanelMarkup(panelKey) {
     `;
   }
 
+  if (panelKey === "settings") {
+    return `
+      <section class="profile-dynamic-content" aria-label="Settings">
+        <h2 class="widget-title">
+          <i class="fa-solid fa-gear" style="color: #c6534e"></i>
+          Settings
+        </h2>
+        <p>
+          This page is currently in progress. Check back soon for settings
+          tools and options.
+        </p>
+      </section>
+    `;
+  }
+
   return `
-    <section class="profile-dynamic-content" aria-label="${panelKey === "settings" ? "Settings" : "My profile"}">
+    <section class="profile-dynamic-content" aria-label="My profile">
       <h2 class="widget-title">
         <i class="fa-solid fa-user" style="color: #c6534e"></i>
         Profile
@@ -1825,7 +1840,10 @@ function initProfileBoardNav() {
   const userNameEl = document.getElementById("profileSidebarUserName");
   const applyUserName = (user) => {
     if (!userNameEl) return;
-    const rawName = String(user?.firstName || user?.name || "User").trim();
+    const firstName = String(user?.firstName || "").trim();
+    const lastName = String(user?.lastName || "").trim();
+    const combinedName = [firstName, lastName].filter(Boolean).join(" ");
+    const rawName = combinedName || String(user?.name || "User").trim();
     userNameEl.textContent = rawName || "User";
   };
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1835,6 +1835,7 @@ function getProfilePanelMarkup(panelKey) {
 function initProfileBoardNav() {
   const panelContainer = document.getElementById("profilePanelContent");
   const navButtons = Array.from(document.querySelectorAll(".profile-nav-link"));
+  const panelStickyNote = document.getElementById("profileContentPanel");
   if (!panelContainer || !navButtons.length) return;
 
   const userNameEl = document.getElementById("profileSidebarUserName");
@@ -1858,9 +1859,67 @@ function initProfileBoardNav() {
     }
   };
 
+  const waitForAnimation = (element, timeoutMs = 420) =>
+    new Promise((resolve) => {
+      if (!element) {
+        resolve();
+        return;
+      }
+
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        element.removeEventListener("animationend", finish);
+        resolve();
+      };
+
+      element.addEventListener("animationend", finish, { once: true });
+      window.setTimeout(finish, timeoutMs);
+    });
+
+  let activePanelKey = "profile";
+  let transitionInFlight = false;
+  let queuedPanelKey = null;
+
+  const transitionToPanel = async (panelKey) => {
+    if (!panelStickyNote) {
+      renderPanel(panelKey);
+      activePanelKey = panelKey;
+      return;
+    }
+
+    transitionInFlight = true;
+    panelStickyNote.classList.add("in-view-hover", "profile-note-leaving");
+    await waitForAnimation(panelStickyNote, 380);
+
+    panelStickyNote.classList.remove("profile-note-leaving");
+    renderPanel(panelKey);
+    activePanelKey = panelKey;
+
+    panelStickyNote.classList.add("profile-note-entering", "in-view-hover");
+    await waitForAnimation(panelStickyNote, 420);
+    panelStickyNote.classList.remove("profile-note-entering", "in-view-hover");
+    transitionInFlight = false;
+
+    if (queuedPanelKey && queuedPanelKey !== activePanelKey) {
+      const nextPanel = queuedPanelKey;
+      queuedPanelKey = null;
+      transitionToPanel(nextPanel);
+    }
+  };
+
   navButtons.forEach((button) => {
     button.addEventListener("click", () => {
-      renderPanel(button.dataset.panel || "profile");
+      const requestedPanel = button.dataset.panel || "profile";
+      if (requestedPanel === activePanelKey && !transitionInFlight) return;
+
+      if (transitionInFlight) {
+        queuedPanelKey = requestedPanel;
+        return;
+      }
+
+      transitionToPanel(requestedPanel);
     });
   });
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1769,6 +1769,99 @@ async function initFeedbackForm() {
   });
 }
 
+function getProfilePanelMarkup(panelKey) {
+  if (panelKey === "support") {
+    return `
+      <section class="profile-dynamic-content" aria-label="Help and support">
+        <h2 class="widget-title">
+          <i class="fa-solid fa-comment-dots" style="color: #c6534e"></i>
+          Feedback
+        </h2>
+        <p class="feedback-intro">
+          Report bugs you run into while using Stick A Pin. We'll send your
+          note straight to our support inbox.
+        </p>
+        <form id="feedbackForm" class="feedback-form" novalidate>
+          <label for="feedbackEmail">Your account email</label>
+          <input id="feedbackEmail" type="email" readonly />
+          <label for="feedbackSubject">Bug summary</label>
+          <input id="feedbackSubject" name="feedbackSubject" type="text" maxlength="120" placeholder="Short summary of the issue" required />
+          <label for="feedbackMessage">What happened?</label>
+          <div class="feedback-attachment-toolbar">
+            <button id="feedbackPhotoBtn" class="feedback-photo-btn" type="button" aria-controls="feedbackPhotoInput feedbackAttachmentList">
+              <i class="fa-regular fa-image" aria-hidden="true"></i>
+              Add photo
+            </button>
+            <span class="feedback-photo-hint">Paste images into the details box or upload from your device.</span>
+          </div>
+          <input id="feedbackPhotoInput" name="feedbackPhotos" type="file" accept="image/*" multiple hidden />
+          <textarea id="feedbackMessage" name="feedbackMessage" maxlength="2000" rows="6" placeholder="Steps to reproduce, expected result, and what you saw." required></textarea>
+          <ul id="feedbackAttachmentList" class="feedback-attachment-list" aria-live="polite"></ul>
+          <button id="feedbackSubmitBtn" type="submit">Send bug report</button>
+        </form>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="profile-dynamic-content" aria-label="${panelKey === "settings" ? "Settings" : "My profile"}">
+      <h2 class="widget-title">
+        <i class="fa-solid fa-user" style="color: #c6534e"></i>
+        Profile
+      </h2>
+      <p>
+        This page is currently in progress. Check back soon for profile tools
+        and details.
+      </p>
+    </section>
+  `;
+}
+
+function initProfileBoardNav() {
+  const panelContainer = document.getElementById("profilePanelContent");
+  const navButtons = Array.from(document.querySelectorAll(".profile-nav-link"));
+  if (!panelContainer || !navButtons.length) return;
+
+  const userNameEl = document.getElementById("profileSidebarUserName");
+  const applyUserName = (user) => {
+    if (!userNameEl) return;
+    const rawName = String(user?.firstName || user?.name || "User").trim();
+    userNameEl.textContent = rawName || "User";
+  };
+
+  const renderPanel = (panelKey) => {
+    panelContainer.innerHTML = getProfilePanelMarkup(panelKey);
+    navButtons.forEach((button) => {
+      button.classList.toggle("is-active", button.dataset.panel === panelKey);
+    });
+
+    if (panelKey === "support") {
+      initFeedbackForm();
+    }
+  };
+
+  navButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      renderPanel(button.dataset.panel || "profile");
+    });
+  });
+
+  document.addEventListener("auth-status-resolved", (event) => {
+    if (event?.detail?.loggedIn) {
+      applyUserName(event.detail.user);
+    }
+  });
+
+  const sidebarLogoutBtn = document.getElementById("profileSidebarLogoutBtn");
+  if (sidebarLogoutBtn) {
+    sidebarLogoutBtn.addEventListener("click", () => {
+      document.getElementById("logoutBtn")?.click();
+    });
+  }
+
+  renderPanel("profile");
+}
+
 
 document.addEventListener("DOMContentLoaded", () => {
   console.log("DOM Fully Loaded - JavaScript Running");
@@ -2116,6 +2209,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initDailyReflectionStatsWidget();
   initWeeklyReflectionStatsWidget();
   initFeedbackForm();
+  initProfileBoardNav();
 
   checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
   initFocusMode();
@@ -2210,6 +2304,11 @@ async function checkAuthStatus({
     updateFocusLogWidget();
 
     updateNavTaskCounter();
+    document.dispatchEvent(
+      new CustomEvent("auth-status-resolved", {
+        detail: { loggedIn: true, user: data.user },
+      }),
+    );
   } else {
     // Protected pages should send logged-out users to login instead of showing a blank shell.
     if (isProtectedPage) {
@@ -2230,6 +2329,11 @@ async function checkAuthStatus({
     if (taskList) {
       taskList.innerHTML = ""; // Clear tasks when logged out
     }
+    document.dispatchEvent(
+      new CustomEvent("auth-status-resolved", {
+        detail: { loggedIn: false },
+      }),
+    );
   }
 }
 

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -81,22 +81,40 @@
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>
 
-    <main
-      class="corkboard placeholder-board"
-      style="max-width: 1100px; margin: 0 auto"
-    >
+    <main class="corkboard profile-board" aria-label="Profile workspace">
+      <aside class="profile-sidebar" aria-label="Profile navigation">
+        <section class="sticky-note white thumbtack profile-user-card">
+          <h2 id="profileSidebarUserName">User</h2>
+          <p class="profile-user-subtitle">Productive Human</p>
+        </section>
+
+        <nav class="profile-side-nav" aria-label="Profile sections">
+          <button class="profile-nav-link is-active" type="button" data-panel="profile">
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            My Profile
+          </button>
+          <button class="profile-nav-link" type="button" data-panel="settings">
+            <i class="fa-solid fa-gear" aria-hidden="true"></i>
+            Settings
+          </button>
+          <button class="profile-nav-link" type="button" data-panel="support">
+            <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+            Help &amp; Support
+          </button>
+        </nav>
+
+        <button id="profileSidebarLogoutBtn" class="profile-logout-btn" type="button">
+          <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
+          Logout
+        </button>
+      </aside>
+
       <section
-        class="sticky-note orange caution-tape page-placeholder"
-        aria-label="Profile page coming soon"
+        id="profileContentPanel"
+        class="sticky-note white caution-tape profile-content-panel"
+        aria-live="polite"
       >
-        <h2 class="widget-title">
-          <i class="fa-solid fa-user" style="color: #c6534e"></i>
-          Profile
-        </h2>
-        <p>
-          This page is currently in progress. Check back soon for profile tools
-          and details.
-        </p>
+        <div id="profilePanelContent"></div>
       </section>
     </main>
 


### PR DESCRIPTION
### Motivation
- Replace the single placeholder profile note with a persistent two-column corkboard so users can switch profile-related sections without a full page refresh. 
- Surface the existing feedback form inside the profile workspace so Help & Support is available in-place on the same sticky-note surface. 

### Description
- Added a left sidebar and dynamic right content panel in `public/profile-page.html` to host the user card, nav links (`My Profile`, `Settings`, `Help & Support`) and a logout button, and a white sticky-note area that updates in place. 
- Implemented new layout and styles in `public/css/main.css` for `.corkboard.profile-board`, `.profile-sidebar`, `.profile-nav-link`, `.profile-logout-btn`, and `.profile-content-panel` with responsive stacking at narrow widths. 
- Added client-side panel controller functions to `public/js/main.js`: `getProfilePanelMarkup(panelKey)` returns markup for `profile`, `settings`, and `support`, and `initProfileBoardNav()` manages in-place switching, wires the sidebar logout to the existing logout flow, and listens for `auth-status-resolved` to populate the sidebar name. 
- Reused the existing feedback form and initialization (`initFeedbackForm()`) so the `Help & Support` panel renders the same feedback UI and behavior without duplicating submission logic. 

### Testing
- Performed static checks with `node --check public/js/main.js` and `node --check server.js`, both of which completed successfully. 
- Verified the new profile initialization is invoked on DOM ready by calling `initProfileBoardNav()` during startup and that auth status dispatch events (`auth-status-resolved`) are emitted when auth is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54b6719e4832698f6a41a1f1c6c96)