### PR TITLE
Add interactive Profile page with sidebar, dynamic panels and logout handling

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -58,9 +58,6 @@
         <li>
           <a href="/calendar-page.html" class="nav-item active">Calendar</a>
         </li>
-        <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
-        <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-        <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
 
       <div class="nav-right">

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1941,6 +1941,191 @@ body.task-panel-open {
   padding-top: 2rem;
 }
 
+.corkboard.profile-board {
+  width: min(1240px, 96vw);
+  height: auto;
+  min-height: 72vh;
+  margin: 0 auto;
+  overflow: visible;
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: clamp(0.9rem, 2.2vw, 1.5rem);
+  align-items: start;
+  padding: clamp(0.9rem, 1.8vw, 1.4rem);
+}
+
+.profile-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-user-card h2 {
+  margin: 0;
+  color: #2f2f2f;
+  text-decoration: none;
+  font-size: clamp(1.4rem, 2.8vw, 2rem);
+}
+
+.profile-user-subtitle {
+  margin-top: 0.2rem;
+  color: #735a4f;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+}
+
+.profile-side-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.profile-nav-link,
+.profile-logout-btn {
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: "Quantico", sans-serif;
+  font-size: 1.02rem;
+  border-radius: 4px;
+  cursor: pointer;
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.22);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.profile-nav-link {
+  background: #fff;
+  color: #272727;
+  padding: 0.85rem 1rem;
+}
+
+.profile-nav-link.is-active {
+  background: #f4eebf;
+  color: #1f1f1f;
+}
+
+.profile-logout-btn {
+  margin-top: 0.25rem;
+  padding: 0.8rem 1rem;
+  background: #d83434;
+  color: #fff;
+  font-weight: 700;
+}
+
+.profile-content-panel {
+  position: relative;
+  min-height: clamp(520px, 68vh, 860px);
+  padding: clamp(1rem, 2.2vw, 1.8rem) !important;
+  transform: rotate(-0.4deg);
+}
+
+.profile-mobile-stamps {
+  display: none;
+}
+
+.profile-stamp-link {
+  border: 2px solid #1f1f1f;
+  background: #1f1f1f;
+  color: #fff;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+}
+
+.profile-stamp-link.is-active {
+  background: #c63232;
+  border-color: #c63232;
+}
+
+.profile-stamp-link.logout-stamp {
+  background: #b51f1f;
+  border-color: #b51f1f;
+}
+
+.profile-content-panel.profile-note-leaving {
+  animation: profile-note-leave 340ms ease-in forwards;
+  pointer-events: none;
+}
+
+.profile-content-panel.profile-note-entering {
+  animation: profile-note-enter 360ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  pointer-events: none;
+}
+
+@keyframes profile-note-leave {
+  0% {
+    transform: translateX(0) translateY(0) rotate(-0.4deg);
+    opacity: 1;
+  }
+  30% {
+    transform: translateX(12px) translateY(-12px) rotate(1.2deg);
+  }
+  100% {
+    transform: translateX(120vw) translateY(-18px) rotate(3deg);
+    opacity: 0;
+  }
+}
+
+@keyframes profile-note-enter {
+  0% {
+    transform: translateX(120vw) translateY(-18px) rotate(3deg);
+    opacity: 0;
+  }
+  65% {
+    transform: translateX(-8px) translateY(0) rotate(-0.8deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(0) translateY(0) rotate(-0.4deg);
+    opacity: 1;
+  }
+}
+
+.profile-dynamic-content .widget-title {
+  margin-bottom: 0.35rem;
+}
+
+.profile-dynamic-content p {
+  width: auto;
+  justify-self: flex-start;
+}
+
+@media (max-width: 900px) {
+  .corkboard.profile-board {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-content-panel {
+    min-height: auto;
+    padding-top: 3.4rem !important;
+  }
+
+  .profile-side-nav {
+    display: none;
+  }
+
+  .profile-logout-btn {
+    display: none;
+  }
+
+  .profile-mobile-stamps {
+    position: absolute;
+    top: 0.6rem;
+    right: 0.7rem;
+    display: inline-flex;
+    gap: 0.45rem;
+    z-index: 3;
+  }
+}
+
 .feedback-note {
   width: min(1180px, 94%) !important;
   padding: clamp(1rem, 2vw, 1.4rem) !important;

--- a/public/css/navbar.css
+++ b/public/css/navbar.css
@@ -29,6 +29,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: nowrap;
   gap: 18px;
   padding: 10px 28px;
   min-height: 70px;
@@ -78,6 +79,8 @@
   font-weight: 700;
   color: var(--text-black);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .nav-links {
@@ -110,6 +113,7 @@
   align-items: center;
   gap: 12px;
   margin-left: auto;
+  flex: 0 0 auto;
   min-width: 0;
 }
 
@@ -217,7 +221,7 @@
   }
 
   .nav-right {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     min-width: 0;
     gap: 8px;
   }
@@ -240,7 +244,7 @@
 
   .nav-welcome {
     font-size: 12px;
-    max-width: min(32ch, 52vw);
+    max-width: min(26ch, 38vw);
     white-space: normal;
     overflow: visible;
     text-overflow: clip;
@@ -293,6 +297,7 @@
 
   .brand-name {
     font-size: 17px;
+    max-width: 120px;
   }
 
   .nav__toggle {
@@ -305,7 +310,7 @@
   }
 
   .nav-welcome {
-    max-width: min(30ch, 58vw);
+    max-width: min(22ch, 34vw);
   }
 
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -64,9 +64,6 @@
         <ul class="nav-links" id="nav-drawer">
           <li><a href="/dashboard.html" class="nav-item active">Board</a></li>
           <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
-          <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
-          <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-          <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
         </ul>
 
         <div class="nav-right">

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -54,11 +54,6 @@
       <ul class="nav-links" id="nav-drawer">
         <li><a href="/dashboard.html" class="nav-item">Board</a></li>
         <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
-        <li>
-          <a href="/feedback-page.html" class="nav-item active">Feedback</a>
-        </li>
-        <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-        <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
       <div class="nav-right">
         <div class="nav-status">

--- a/public/focus-page.html
+++ b/public/focus-page.html
@@ -55,11 +55,6 @@
       <ul class="nav-links" id="nav-drawer">
         <li><a href="/dashboard.html" class="nav-item">Board</a></li>
         <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
-        <li>
-          <a href="/feedback-page.html" class="nav-item">Feedback</a>
-        </li>
-        <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-        <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
       <div class="nav-right">
         <div class="nav-status">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1769,6 +1769,209 @@ async function initFeedbackForm() {
   });
 }
 
+function getProfilePanelMarkup(panelKey) {
+  if (panelKey === "support") {
+    return `
+      <section class="profile-dynamic-content" aria-label="Help and support">
+        <h2 class="widget-title">
+          <i class="fa-solid fa-comment-dots" style="color: #c6534e"></i>
+          Feedback
+        </h2>
+        <p class="feedback-intro">
+          Report bugs you run into while using Stick A Pin. We'll send your
+          note straight to our support inbox.
+        </p>
+        <form id="feedbackForm" class="feedback-form" novalidate>
+          <label for="feedbackEmail">Your account email</label>
+          <input id="feedbackEmail" type="email" readonly />
+          <label for="feedbackSubject">Bug summary</label>
+          <input id="feedbackSubject" name="feedbackSubject" type="text" maxlength="120" placeholder="Short summary of the issue" required />
+          <label for="feedbackMessage">What happened?</label>
+          <div class="feedback-attachment-toolbar">
+            <button id="feedbackPhotoBtn" class="feedback-photo-btn" type="button" aria-controls="feedbackPhotoInput feedbackAttachmentList">
+              <i class="fa-regular fa-image" aria-hidden="true"></i>
+              Add photo
+            </button>
+            <span class="feedback-photo-hint">Paste images into the details box or upload from your device.</span>
+          </div>
+          <input id="feedbackPhotoInput" name="feedbackPhotos" type="file" accept="image/*" multiple hidden />
+          <textarea id="feedbackMessage" name="feedbackMessage" maxlength="2000" rows="6" placeholder="Steps to reproduce, expected result, and what you saw." required></textarea>
+          <ul id="feedbackAttachmentList" class="feedback-attachment-list" aria-live="polite"></ul>
+          <button id="feedbackSubmitBtn" type="submit">Send bug report</button>
+        </form>
+      </section>
+    `;
+  }
+
+  if (panelKey === "settings") {
+    return `
+      <section class="profile-dynamic-content" aria-label="Settings">
+        <h2 class="widget-title">
+          <i class="fa-solid fa-gear" style="color: #c6534e"></i>
+          Settings
+        </h2>
+        <p>
+          This page is currently in progress. Check back soon for settings
+          tools and options.
+        </p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="profile-dynamic-content" aria-label="My profile">
+      <h2 class="widget-title">
+        <i class="fa-solid fa-user" style="color: #c6534e"></i>
+        Profile
+      </h2>
+      <p>
+        This page is currently in progress. Check back soon for profile tools
+        and details.
+      </p>
+    </section>
+  `;
+}
+
+function initProfileBoardNav() {
+  const panelContainer = document.getElementById("profilePanelContent");
+  const navButtons = Array.from(document.querySelectorAll(".profile-panel-trigger"));
+  const panelStickyNote = document.getElementById("profileContentPanel");
+  if (!panelContainer || !navButtons.length) return;
+
+  const userNameEl = document.getElementById("profileSidebarUserName");
+  const applyUserName = (user) => {
+    if (!userNameEl) return;
+    const firstName = String(user?.firstName || "").trim();
+    const lastName = String(user?.lastName || "").trim();
+    const combinedName = [firstName, lastName].filter(Boolean).join(" ");
+    const rawName = combinedName || String(user?.name || "User").trim();
+    userNameEl.textContent = rawName || "User";
+  };
+
+  const renderPanel = (panelKey) => {
+    panelContainer.innerHTML = getProfilePanelMarkup(panelKey);
+    navButtons.forEach((button) => {
+      button.classList.toggle("is-active", button.dataset.panel === panelKey);
+    });
+
+    if (panelKey === "support") {
+      initFeedbackForm();
+    }
+  };
+
+  const waitForAnimation = (element, timeoutMs = 420) =>
+    new Promise((resolve) => {
+      if (!element) {
+        resolve();
+        return;
+      }
+
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        element.removeEventListener("animationend", finish);
+        resolve();
+      };
+
+      element.addEventListener("animationend", finish, { once: true });
+      window.setTimeout(finish, timeoutMs);
+    });
+
+  let activePanelKey = "profile";
+  let transitionInFlight = false;
+  let queuedPanelKey = null;
+
+  const transitionToPanel = async (panelKey) => {
+    if (!panelStickyNote) {
+      renderPanel(panelKey);
+      activePanelKey = panelKey;
+      return;
+    }
+
+    transitionInFlight = true;
+    panelStickyNote.classList.add("in-view-hover", "profile-note-leaving");
+    await waitForAnimation(panelStickyNote, 380);
+
+    panelStickyNote.classList.remove("profile-note-leaving");
+    renderPanel(panelKey);
+    activePanelKey = panelKey;
+
+    panelStickyNote.classList.add("profile-note-entering", "in-view-hover");
+    await waitForAnimation(panelStickyNote, 420);
+    panelStickyNote.classList.remove("profile-note-entering", "in-view-hover");
+    transitionInFlight = false;
+
+    if (queuedPanelKey && queuedPanelKey !== activePanelKey) {
+      const nextPanel = queuedPanelKey;
+      queuedPanelKey = null;
+      transitionToPanel(nextPanel);
+    }
+  };
+
+  navButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const requestedPanel = button.dataset.panel || "profile";
+      if (requestedPanel === activePanelKey && !transitionInFlight) return;
+
+      if (transitionInFlight) {
+        queuedPanelKey = requestedPanel;
+        return;
+      }
+
+      transitionToPanel(requestedPanel);
+    });
+  });
+
+  document.addEventListener("auth-status-resolved", (event) => {
+    if (event?.detail?.loggedIn) {
+      applyUserName(event.detail.user);
+    }
+  });
+
+  const triggerLogout = async () => {
+    const navLogoutBtn = document.getElementById("logoutBtn");
+    if (navLogoutBtn) {
+      navLogoutBtn.click();
+      return;
+    }
+
+    try {
+      const response = await apiFetch("/logout", {
+        credentials: "include",
+        method: "POST",
+      });
+
+      if (response.ok) {
+        Toast.show({
+          message: "Logged out successfully",
+          type: "success",
+          duration: 2000,
+        });
+        window.location.href = "/login.html";
+      } else {
+        const data = await parseApiResponse(response);
+        alert("Logout failed: " + (data.error || "Unknown error"));
+      }
+    } catch (error) {
+      console.error("Logout request failed:", error);
+      alert("Logout failed due to a network/server issue.");
+    }
+  };
+
+  const sidebarLogoutBtn = document.getElementById("profileSidebarLogoutBtn");
+  if (sidebarLogoutBtn) {
+    sidebarLogoutBtn.addEventListener("click", triggerLogout);
+  }
+
+  const mobileLogoutBtn = document.getElementById("profileMobileLogoutBtn");
+  if (mobileLogoutBtn) {
+    mobileLogoutBtn.addEventListener("click", triggerLogout);
+  }
+
+  renderPanel("profile");
+}
+
 
 document.addEventListener("DOMContentLoaded", () => {
   console.log("DOM Fully Loaded - JavaScript Running");
@@ -2116,6 +2319,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initDailyReflectionStatsWidget();
   initWeeklyReflectionStatsWidget();
   initFeedbackForm();
+  initProfileBoardNav();
 
   checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
   initFocusMode();
@@ -2210,6 +2414,11 @@ async function checkAuthStatus({
     updateFocusLogWidget();
 
     updateNavTaskCounter();
+    document.dispatchEvent(
+      new CustomEvent("auth-status-resolved", {
+        detail: { loggedIn: true, user: data.user },
+      }),
+    );
   } else {
     // Protected pages should send logged-out users to login instead of showing a blank shell.
     if (isProtectedPage) {
@@ -2230,6 +2439,11 @@ async function checkAuthStatus({
     if (taskList) {
       taskList.innerHTML = ""; // Clear tasks when logged out
     }
+    document.dispatchEvent(
+      new CustomEvent("auth-status-resolved", {
+        detail: { loggedIn: false },
+      }),
+    );
   }
 }
 

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -56,9 +56,6 @@
       <ul class="nav-links" id="nav-drawer">
         <li><a href="/dashboard.html" class="nav-item">Board</a></li>
         <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
-        <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
-        <li><a href="/settings-page.html" class="nav-item">Settings</a></li>
-        <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
 
       <div class="nav-right">
@@ -81,22 +78,74 @@
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>
 
-    <main
-      class="corkboard placeholder-board"
-      style="max-width: 1100px; margin: 0 auto"
-    >
+    <main class="corkboard profile-board" aria-label="Profile workspace">
+      <aside class="profile-sidebar" aria-label="Profile navigation">
+        <section class="sticky-note white thumbtack profile-user-card">
+          <h2 id="profileSidebarUserName">User</h2>
+          <p class="profile-user-subtitle">Productive Human</p>
+        </section>
+
+        <nav class="profile-side-nav" aria-label="Profile sections">
+          <button class="profile-nav-link profile-panel-trigger is-active" type="button" data-panel="profile" aria-label="Show My Profile">
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            My Profile
+          </button>
+          <button class="profile-nav-link profile-panel-trigger" type="button" data-panel="settings" aria-label="Show Settings">
+            <i class="fa-solid fa-gear" aria-hidden="true"></i>
+            Settings
+          </button>
+          <button class="profile-nav-link profile-panel-trigger" type="button" data-panel="support" aria-label="Show Help and Support">
+            <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+            Help &amp; Support
+          </button>
+        </nav>
+
+        <button id="profileSidebarLogoutBtn" class="profile-logout-btn" type="button">
+          <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
+          Logout
+        </button>
+      </aside>
+
       <section
-        class="sticky-note orange caution-tape page-placeholder"
-        aria-label="Profile page coming soon"
+        id="profileContentPanel"
+        class="sticky-note white caution-tape profile-content-panel"
+        aria-live="polite"
       >
-        <h2 class="widget-title">
-          <i class="fa-solid fa-user" style="color: #c6534e"></i>
-          Profile
-        </h2>
-        <p>
-          This page is currently in progress. Check back soon for profile tools
-          and details.
-        </p>
+        <div class="profile-mobile-stamps" aria-label="Profile section quick actions">
+          <button
+            class="profile-stamp-link profile-panel-trigger is-active"
+            type="button"
+            data-panel="profile"
+            aria-label="Show My Profile"
+          >
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+          </button>
+          <button
+            class="profile-stamp-link profile-panel-trigger"
+            type="button"
+            data-panel="settings"
+            aria-label="Show Settings"
+          >
+            <i class="fa-solid fa-gear" aria-hidden="true"></i>
+          </button>
+          <button
+            class="profile-stamp-link profile-panel-trigger"
+            type="button"
+            data-panel="support"
+            aria-label="Show Help and Support"
+          >
+            <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
+          </button>
+          <button
+            id="profileMobileLogoutBtn"
+            class="profile-stamp-link logout-stamp"
+            type="button"
+            aria-label="Logout"
+          >
+            <i class="fa-solid fa-right-from-bracket" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div id="profilePanelContent"></div>
       </section>
     </main>
 

--- a/public/settings-page.html
+++ b/public/settings-page.html
@@ -54,11 +54,6 @@
       <ul class="nav-links" id="nav-drawer">
         <li><a href="/dashboard.html" class="nav-item">Board</a></li>
         <li><a href="/calendar-page.html" class="nav-item">Calendar</a></li>
-        <li><a href="/feedback-page.html" class="nav-item">Feedback</a></li>
-        <li>
-          <a href="/settings-page.html" class="nav-item active">Settings</a>
-        </li>
-        <li><a href="#" id="logoutBtn" class="nav-item">Logout</a></li>
       </ul>
       <div class="nav-right">
         <div class="nav-status">


### PR DESCRIPTION
### Motivation
- Provide a first-class profile workspace with quick access to Profile, Settings and Help/Support from a dedicated page and mobile-friendly controls. 
- Replace ad-hoc nav links with a focused profile surface that contains its own logout controls and contextual tools. 
- Reuse the existing feedback flow inside the profile support panel to keep support UI consolidated. 

### Description
- Add a new profile workspace layout in `public/profile-page.html` including a sidebar, mobile stamps, panel container and logout buttons. 
- Implement dynamic panel rendering and animated transitions with new functions `getProfilePanelMarkup` and `initProfileBoardNav` in `public/js/main.js`, and call `initProfileBoardNav` during `DOMContentLoaded`. 
- Emit an `auth-status-resolved` custom event from `checkAuthStatus` to populate the profile UI with user data and wire logout behavior that either clicks a nav logout link or calls `/logout`. 
- Add profile-specific styles in `public/css/main.css` and adjust navbar layout/overflow/responsive rules in `public/css/navbar.css`; remove static `Feedback`, `Settings`, and `Logout` entries from various page nav lists to rely on the profile surface. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54b6719e4832698f6a41a1f1c6c96)