### PR TITLE
Add interactive monthly calendar with sticky-note day tiles and month navigation

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -91,6 +91,9 @@
             <button id="calendarNextBtn" class="calendar-nav-btn" type="button" aria-label="Next month">
               <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
             </button>
+            <button id="calendarTodayBtn" class="calendar-nav-btn calendar-today-btn" type="button" aria-label="Jump to current month and day">
+              Today
+            </button>
           </div>
         </header>
 

--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -80,22 +80,31 @@
     </nav>
     <div id="nav-backdrop" aria-hidden="true"></div>
 
-    <main
-      class="corkboard placeholder-board"
-      style="max-width: 1100px; margin: 0 auto"
-    >
-      <section
-        class="sticky-note orange caution-tape page-placeholder"
-        aria-label="Calendar page coming soon"
-      >
-        <h2 class="widget-title">
-          <i class="fa-solid fa-calendar-days" style="color: #c6534e"></i>
-          Calendar
-        </h2>
-        <p>
-          This page is currently in progress. Check back soon for your full
-          calendar view.
-        </p>
+    <main class="corkboard calendar-board" aria-label="Monthly calendar">
+      <section class="calendar-shell" id="calendarApp">
+        <header class="calendar-header">
+          <h1 id="calendarMonthTitle" class="calendar-month-title">Month YYYY</h1>
+          <div class="calendar-controls" aria-label="Month navigation">
+            <button id="calendarPrevBtn" class="calendar-nav-btn" type="button" aria-label="Previous month">
+              <i class="fa-solid fa-chevron-left" aria-hidden="true"></i>
+            </button>
+            <button id="calendarNextBtn" class="calendar-nav-btn" type="button" aria-label="Next month">
+              <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+            </button>
+          </div>
+        </header>
+
+        <div class="calendar-weekdays" aria-hidden="true">
+          <span>Sunday</span>
+          <span>Monday</span>
+          <span>Tuesday</span>
+          <span>Wednesday</span>
+          <span>Thursday</span>
+          <span>Friday</span>
+          <span>Saturday</span>
+        </div>
+
+        <div id="calendarGrid" class="calendar-grid" role="grid" aria-label="Calendar days"></div>
       </section>
     </main>
 

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -592,6 +592,10 @@
   aspect-ratio: 1 / 1;
 }
 
+.calendar-day.has-due-task {
+  background: #f7dfe8;
+}
+
 .calendar-day::before {
   content: "";
   position: absolute;

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -497,7 +497,7 @@
   width: min(1200px, 95vw);
   height: auto;
   min-height: calc(100vh - 110px);
-  margin: 12px auto 20px;
+  margin: 0 auto;
   padding: clamp(16px, 2.5vw, 28px);
 }
 
@@ -541,6 +541,14 @@
 
 .calendar-nav-btn:hover {
   transform: translateY(-1px);
+}
+
+.calendar-today-btn {
+  width: auto;
+  min-width: 78px;
+  padding: 0 12px;
+  font-family: "Itim", serif;
+  font-size: 18px;
 }
 
 .calendar-weekdays {

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -489,3 +489,161 @@
   background: #b33a35;
   color: white;
 }
+
+/* ============================================================
+   CALENDAR PAGE
+   ============================================================ */
+.corkboard.calendar-board {
+  width: min(1200px, 95vw);
+  height: auto;
+  min-height: calc(100vh - 110px);
+  margin: 12px auto 20px;
+  padding: clamp(16px, 2.5vw, 28px);
+}
+
+.calendar-shell {
+  width: 100%;
+}
+
+.calendar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.calendar-month-title {
+  margin: 0;
+  color: #222;
+  text-decoration: none;
+  font-family: "Itim", serif;
+  font-size: clamp(34px, 5.2vw, 56px);
+}
+
+.calendar-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.calendar-nav-btn {
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 10px;
+  background: #fff8ea;
+  color: #6b4a35;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.calendar-nav-btn:hover {
+  transform: translateY(-1px);
+}
+
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0 0 10px;
+}
+
+.calendar-weekdays span {
+  text-align: center;
+  font-family: "Itim", serif;
+  font-size: clamp(11px, 1.2vw, 15px);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #4f3023;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: clamp(10px, 1.3vw, 16px);
+}
+
+.calendar-day,
+.calendar-empty {
+  min-height: clamp(88px, 13vw, 140px);
+}
+
+.calendar-day {
+  position: relative;
+  background: #fff;
+  border-radius: 2px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.22);
+  padding: 10px 10px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.calendar-day::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%) rotate(-2deg);
+  width: 46px;
+  height: 14px;
+  background: rgba(245, 229, 197, 0.8);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+.calendar-day-number {
+  font-family: "Gochi Hand", cursive;
+  font-size: clamp(28px, 3vw, 38px);
+  line-height: 1;
+  color: #1f1f1f;
+}
+
+.calendar-day.today .calendar-day-number {
+  color: #c83939;
+  position: relative;
+}
+
+.calendar-day.today .calendar-day-number::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 1.65em;
+  height: 1.35em;
+  border: 2px solid #cf3b3b;
+  border-radius: 58% 46% 56% 48%;
+  transform: translate(-50%, -50%) rotate(-11deg);
+}
+
+.calendar-today-label {
+  margin-top: 5px;
+  font-family: "Gochi Hand", cursive;
+  font-size: clamp(14px, 1.5vw, 20px);
+  color: #cf3b3b;
+  text-transform: lowercase;
+}
+
+@media (max-width: 760px) {
+  .calendar-weekdays span {
+    font-size: 10px;
+  }
+
+  .calendar-day,
+  .calendar-empty {
+    min-height: 72px;
+  }
+
+  .calendar-day {
+    padding: 8px 8px 6px;
+  }
+
+  .calendar-day-number {
+    font-size: clamp(20px, 5.3vw, 30px);
+  }
+
+  .calendar-today-label {
+    font-size: 13px;
+  }
+}

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -495,10 +495,12 @@
    ============================================================ */
 .corkboard.calendar-board {
   width: min(1200px, 95vw);
-  height: fit-content;
-  min-height: 0;
+  height: auto !important;
+  min-height: max-content;
+  overflow: visible;
   margin: 0 auto;
   padding: clamp(16px, 2.5vw, 28px);
+  padding-bottom: clamp(28px, 4vw, 44px);
 }
 
 .calendar-shell {

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -575,7 +575,7 @@
 
 .calendar-day,
 .calendar-empty {
-  min-height: clamp(88px, 13vw, 140px);
+  min-height: clamp(64px, 8vw, 112px);
 }
 
 .calendar-day {
@@ -587,6 +587,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  aspect-ratio: 1 / 1;
 }
 
 .calendar-day::before {
@@ -633,6 +634,48 @@
   text-transform: lowercase;
 }
 
+
+
+.calendar-day.calendar-note-leaving {
+  animation: calendar-note-leave 300ms ease-in forwards;
+  animation-delay: var(--note-stagger, 0ms);
+  pointer-events: none;
+}
+
+.calendar-day.calendar-note-entering {
+  animation: calendar-note-enter 360ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
+  animation-delay: var(--note-stagger, 0ms);
+}
+
+@keyframes calendar-note-leave {
+  0% {
+    transform: translateX(0) translateY(0) rotate(-1deg);
+    opacity: 1;
+  }
+  35% {
+    transform: translateX(8px) translateY(-10px) rotate(1deg);
+  }
+  100% {
+    transform: translateX(110vw) translateY(-15px) rotate(3deg);
+    opacity: 0;
+  }
+}
+
+@keyframes calendar-note-enter {
+  0% {
+    transform: translateX(110vw) translateY(-15px) rotate(3deg);
+    opacity: 0;
+  }
+  70% {
+    transform: translateX(-6px) translateY(0) rotate(-0.8deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(0) translateY(0) rotate(-1deg);
+    opacity: 1;
+  }
+}
+
 @media (max-width: 760px) {
   .calendar-weekdays span {
     font-size: 10px;
@@ -640,7 +683,7 @@
 
   .calendar-day,
   .calendar-empty {
-    min-height: 72px;
+    min-height: 54px;
   }
 
   .calendar-day {

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -495,8 +495,8 @@
    ============================================================ */
 .corkboard.calendar-board {
   width: min(1200px, 95vw);
-  height: auto;
-  min-height: calc(100vh - 110px);
+  height: fit-content;
+  min-height: 0;
   margin: 0 auto;
   padding: clamp(16px, 2.5vw, 28px);
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2505,10 +2505,84 @@ document.addEventListener("DOMContentLoaded", () => {
   initWeeklyReflectionStatsWidget();
   initFeedbackForm();
   initProfileBoardNav();
+  initCalendarPage();
 
   checkAuthStatus({ isLoginPage, isRegisterPage, isProtectedPage, isHomePage }); // Check authentication status on page load
   initFocusMode();
 });
+
+
+function initCalendarPage() {
+  const calendarGrid = document.getElementById("calendarGrid");
+  const monthTitle = document.getElementById("calendarMonthTitle");
+  const prevBtn = document.getElementById("calendarPrevBtn");
+  const nextBtn = document.getElementById("calendarNextBtn");
+
+  if (!calendarGrid || !monthTitle || !prevBtn || !nextBtn) return;
+
+  const today = new Date();
+  const todayYear = today.getFullYear();
+  const todayMonth = today.getMonth();
+  const todayDate = today.getDate();
+
+  let visibleDate = new Date(todayYear, todayMonth, 1);
+
+  const renderCalendar = () => {
+    const year = visibleDate.getFullYear();
+    const month = visibleDate.getMonth();
+    const firstDayOfMonth = new Date(year, month, 1).getDay();
+    const totalDays = new Date(year, month + 1, 0).getDate();
+
+    monthTitle.textContent = visibleDate.toLocaleString("en-US", {
+      month: "long",
+      year: "numeric",
+    });
+
+    calendarGrid.innerHTML = "";
+
+    for (let i = 0; i < firstDayOfMonth; i += 1) {
+      const emptySlot = document.createElement("div");
+      emptySlot.className = "calendar-empty";
+      emptySlot.setAttribute("aria-hidden", "true");
+      calendarGrid.appendChild(emptySlot);
+    }
+
+    for (let day = 1; day <= totalDays; day += 1) {
+      const dayNote = document.createElement("article");
+      dayNote.className = "calendar-day";
+      dayNote.setAttribute("role", "gridcell");
+      dayNote.setAttribute("aria-label", `${monthTitle.textContent} ${day}`);
+
+      const dayNumber = document.createElement("span");
+      dayNumber.className = "calendar-day-number";
+      dayNumber.textContent = String(day);
+      dayNote.appendChild(dayNumber);
+
+      const isToday = year === todayYear && month === todayMonth && day === todayDate;
+      if (isToday) {
+        dayNote.classList.add("today");
+        const todayLabel = document.createElement("span");
+        todayLabel.className = "calendar-today-label";
+        todayLabel.textContent = "today";
+        dayNote.appendChild(todayLabel);
+      }
+
+      calendarGrid.appendChild(dayNote);
+    }
+  };
+
+  prevBtn.addEventListener("click", () => {
+    visibleDate = new Date(visibleDate.getFullYear(), visibleDate.getMonth() - 1, 1);
+    renderCalendar();
+  });
+
+  nextBtn.addEventListener("click", () => {
+    visibleDate = new Date(visibleDate.getFullYear(), visibleDate.getMonth() + 1, 1);
+    renderCalendar();
+  });
+
+  renderCalendar();
+}
 
 async function updateNavTaskCounter() {
   const counters = document.querySelectorAll(".item-counter");

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2566,7 +2566,7 @@ function initCalendarPage() {
 
       dueDateLookup = new Set(
         tasks
-          .filter((task) => task?.status === "active" || task?.status === "completed")
+          .filter((task) => task?.status === "active")
           .map((task) => toLocalDateKey(task?.dueDate))
           .filter(Boolean),
       );

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2517,8 +2517,9 @@ function initCalendarPage() {
   const monthTitle = document.getElementById("calendarMonthTitle");
   const prevBtn = document.getElementById("calendarPrevBtn");
   const nextBtn = document.getElementById("calendarNextBtn");
+  const todayBtn = document.getElementById("calendarTodayBtn");
 
-  if (!calendarGrid || !monthTitle || !prevBtn || !nextBtn) return;
+  if (!calendarGrid || !monthTitle || !prevBtn || !nextBtn || !todayBtn) return;
 
   const today = new Date();
   const todayYear = today.getFullYear();
@@ -2579,6 +2580,14 @@ function initCalendarPage() {
   nextBtn.addEventListener("click", () => {
     visibleDate = new Date(visibleDate.getFullYear(), visibleDate.getMonth() + 1, 1);
     renderCalendar();
+  });
+
+  todayBtn.addEventListener("click", () => {
+    visibleDate = new Date(todayYear, todayMonth, 1);
+    renderCalendar();
+
+    const todayCell = calendarGrid.querySelector(".calendar-day.today");
+    todayCell?.scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest" });
   });
 
   renderCalendar();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2528,6 +2528,52 @@ function initCalendarPage() {
 
   let visibleDate = new Date(todayYear, todayMonth, 1);
   let isTransitioning = false;
+  let dueDateLookup = new Set();
+
+
+  const toLocalDateKey = (value) => {
+    if (!value) return null;
+
+    if (typeof value === "string") {
+      const directMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+      if (directMatch) {
+        return `${directMatch[1]}-${directMatch[2]}-${directMatch[3]}`;
+      }
+    }
+
+    const parsedDate = new Date(value);
+    if (Number.isNaN(parsedDate.getTime())) return null;
+
+    const year = parsedDate.getFullYear();
+    const month = String(parsedDate.getMonth() + 1).padStart(2, "0");
+    const day = String(parsedDate.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  };
+
+  const buildVisibleDateKey = (year, month, day) => {
+    const normalizedMonth = String(month + 1).padStart(2, "0");
+    const normalizedDay = String(day).padStart(2, "0");
+    return `${year}-${normalizedMonth}-${normalizedDay}`;
+  };
+
+  const loadDueDateHighlights = async () => {
+    try {
+      const response = await apiFetch("/tasks", { credentials: "include" });
+      if (!response.ok) return;
+
+      const tasks = await response.json();
+      if (!Array.isArray(tasks)) return;
+
+      dueDateLookup = new Set(
+        tasks
+          .filter((task) => task?.status === "active" || task?.status === "completed")
+          .map((task) => toLocalDateKey(task?.dueDate))
+          .filter(Boolean),
+      );
+    } catch (error) {
+      console.error("Unable to load calendar due-date highlights:", error);
+    }
+  };
 
   const waitForAnimation = (element, fallbackMs = 360) =>
     new Promise((resolve) => {
@@ -2573,6 +2619,11 @@ function initCalendarPage() {
       dayNote.className = "calendar-day";
       dayNote.setAttribute("role", "gridcell");
       dayNote.setAttribute("aria-label", `${monthTitle.textContent} ${day}`);
+
+      const visibleDateKey = buildVisibleDateKey(year, month, day);
+      if (dueDateLookup.has(visibleDateKey)) {
+        dayNote.classList.add("has-due-task");
+      }
 
       if (animateIn) {
         dayNote.classList.add("calendar-note-entering");
@@ -2634,7 +2685,9 @@ function initCalendarPage() {
     transitionToMonth(new Date(todayYear, todayMonth, 1), { focusToday: true });
   });
 
-  renderCalendar({ animateIn: true });
+  loadDueDateHighlights().finally(() => {
+    renderCalendar({ animateIn: true });
+  });
 }
 
 async function updateNavTaskCounter() {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2527,8 +2527,28 @@ function initCalendarPage() {
   const todayDate = today.getDate();
 
   let visibleDate = new Date(todayYear, todayMonth, 1);
+  let isTransitioning = false;
 
-  const renderCalendar = () => {
+  const waitForAnimation = (element, fallbackMs = 360) =>
+    new Promise((resolve) => {
+      if (!element) {
+        resolve();
+        return;
+      }
+
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        element.removeEventListener("animationend", finish);
+        resolve();
+      };
+
+      element.addEventListener("animationend", finish, { once: true });
+      window.setTimeout(finish, fallbackMs);
+    });
+
+  const renderCalendar = ({ animateIn = false } = {}) => {
     const year = visibleDate.getFullYear();
     const month = visibleDate.getMonth();
     const firstDayOfMonth = new Date(year, month, 1).getDay();
@@ -2554,6 +2574,11 @@ function initCalendarPage() {
       dayNote.setAttribute("role", "gridcell");
       dayNote.setAttribute("aria-label", `${monthTitle.textContent} ${day}`);
 
+      if (animateIn) {
+        dayNote.classList.add("calendar-note-entering");
+        dayNote.style.setProperty("--note-stagger", `${Math.min(day * 12, 260)}ms`);
+      }
+
       const dayNumber = document.createElement("span");
       dayNumber.className = "calendar-day-number";
       dayNumber.textContent = String(day);
@@ -2572,25 +2597,44 @@ function initCalendarPage() {
     }
   };
 
+  const transitionToMonth = async (nextVisibleDate, { focusToday = false } = {}) => {
+    if (isTransitioning) return;
+    isTransitioning = true;
+
+    const existingNotes = Array.from(calendarGrid.querySelectorAll(".calendar-day"));
+    if (existingNotes.length) {
+      existingNotes.forEach((note, index) => {
+        note.classList.add("calendar-note-leaving");
+        note.style.setProperty("--note-stagger", `${Math.min(index * 10, 180)}ms`);
+      });
+
+      await waitForAnimation(existingNotes[existingNotes.length - 1], 360);
+    }
+
+    visibleDate = new Date(nextVisibleDate.getFullYear(), nextVisibleDate.getMonth(), 1);
+    renderCalendar({ animateIn: true });
+
+    if (focusToday) {
+      const todayCell = calendarGrid.querySelector(".calendar-day.today");
+      todayCell?.scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest" });
+    }
+
+    isTransitioning = false;
+  };
+
   prevBtn.addEventListener("click", () => {
-    visibleDate = new Date(visibleDate.getFullYear(), visibleDate.getMonth() - 1, 1);
-    renderCalendar();
+    transitionToMonth(new Date(visibleDate.getFullYear(), visibleDate.getMonth() - 1, 1));
   });
 
   nextBtn.addEventListener("click", () => {
-    visibleDate = new Date(visibleDate.getFullYear(), visibleDate.getMonth() + 1, 1);
-    renderCalendar();
+    transitionToMonth(new Date(visibleDate.getFullYear(), visibleDate.getMonth() + 1, 1));
   });
 
   todayBtn.addEventListener("click", () => {
-    visibleDate = new Date(todayYear, todayMonth, 1);
-    renderCalendar();
-
-    const todayCell = calendarGrid.querySelector(".calendar-day.today");
-    todayCell?.scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest" });
+    transitionToMonth(new Date(todayYear, todayMonth, 1), { focusToday: true });
   });
 
-  renderCalendar();
+  renderCalendar({ animateIn: true });
 }
 
 async function updateNavTaskCounter() {


### PR DESCRIPTION
### Motivation
- Replace the placeholder calendar with a usable month view so users can see dates laid out in a corkboard/sticky-note style and navigate months.
- Provide a visual design that matches existing app aesthetics: small white sticky notes with tape, hand-written numbers, and a distinct highlight for the current day.

### Description
- Replaced the placeholder shell with a full month-view layout and controls in `public/calendar-page.html`, including a month title and previous/next buttons, a Sunday-first weekday row, and a `#calendarGrid` container.
- Added calendar-specific styling in `public/css/stickies.css` so each day is rendered as a small white sticky note with a tape strip, handwritten font (`Gochi Hand`) for the day number, responsive sizing, and a red hand-drawn circle + label for today.
- Implemented `initCalendarPage()` in `public/js/main.js` that renders the visible month, aligns day 1 under the correct weekday (Sunday-based), populates empty slots for leading days, generates all day tiles, detects the user’s current date and marks it with `.today`, and hooks month navigation to the prev/next buttons.
- Hooked the calendar initializer into the existing boot sequence by calling `initCalendarPage()` during `DOMContentLoaded` and added ARIA attributes (`role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6996175708326a65644bb2a3f2c41)