### PR TITLE
Abbreviate calendar weekday labels on small screens

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -98,13 +98,13 @@
         </header>
 
         <div class="calendar-weekdays" aria-hidden="true">
-          <span>Sunday</span>
-          <span>Monday</span>
-          <span>Tuesday</span>
-          <span>Wednesday</span>
-          <span>Thursday</span>
-          <span>Friday</span>
-          <span>Saturday</span>
+          <span><span class="weekday-full">Sunday</span><span class="weekday-short">Sun</span></span>
+          <span><span class="weekday-full">Monday</span><span class="weekday-short">Mon</span></span>
+          <span><span class="weekday-full">Tuesday</span><span class="weekday-short">Tue</span></span>
+          <span><span class="weekday-full">Wednesday</span><span class="weekday-short">Wed</span></span>
+          <span><span class="weekday-full">Thursday</span><span class="weekday-short">Thur</span></span>
+          <span><span class="weekday-full">Friday</span><span class="weekday-short">Fri</span></span>
+          <span><span class="weekday-full">Saturday</span><span class="weekday-short">Sat</span></span>
         </div>
 
         <div id="calendarGrid" class="calendar-grid" role="grid" aria-label="Calendar days"></div>

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -569,6 +569,10 @@
   color: #4f3023;
 }
 
+.weekday-short {
+  display: none;
+}
+
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
@@ -685,6 +689,14 @@
 @media (max-width: 760px) {
   .calendar-weekdays span {
     font-size: 10px;
+  }
+
+  .weekday-full {
+    display: none;
+  }
+
+  .weekday-short {
+    display: inline;
   }
 
   .calendar-day,


### PR DESCRIPTION
### Motivation
- Improve calendar header readability on narrow viewports by switching full weekday names to short abbreviations when space is constrained.

### Description
- Updated the weekday header markup in `public/calendar-page.html` to include both full and short labels wrapped in `weekday-full` and `weekday-short` spans for each day.
- Added CSS to `public/css/stickies.css` to hide `.weekday-short` by default and to hide `.weekday-full` and show `.weekday-short` under the `@media (max-width: 760px)` rule.
- The short labels used are `Sun`, `Mon`, `Tue`, `Wed`, `Thur`, `Fri`, and `Sat`.
- Files modified are `public/calendar-page.html` and `public/css/stickies.css`.

### Testing
- No automated tests were run because there is no `test` script configured in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ce1fd2688326be5a5e9347e11018)