### PR TITLE
Calendar: responsive weekday labels and interactive due-tasks overlay

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -98,13 +98,13 @@
         </header>
 
         <div class="calendar-weekdays" aria-hidden="true">
-          <span>Sunday</span>
-          <span>Monday</span>
-          <span>Tuesday</span>
-          <span>Wednesday</span>
-          <span>Thursday</span>
-          <span>Friday</span>
-          <span>Saturday</span>
+          <span><span class="weekday-full">Sunday</span><span class="weekday-short">Sun</span></span>
+          <span><span class="weekday-full">Monday</span><span class="weekday-short">Mon</span></span>
+          <span><span class="weekday-full">Tuesday</span><span class="weekday-short">Tue</span></span>
+          <span><span class="weekday-full">Wednesday</span><span class="weekday-short">Wed</span></span>
+          <span><span class="weekday-full">Thursday</span><span class="weekday-short">Thur</span></span>
+          <span><span class="weekday-full">Friday</span><span class="weekday-short">Fri</span></span>
+          <span><span class="weekday-full">Saturday</span><span class="weekday-short">Sat</span></span>
         </div>
 
         <div id="calendarGrid" class="calendar-grid" role="grid" aria-label="Calendar days"></div>

--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -134,5 +134,103 @@
       </button>
       <div class="toast__progress"></div>
     </div>
+
+    <aside id="task-detail-panel" class="task-detail-panel" aria-hidden="true">
+      <div class="task-detail-panel__header">
+        <h3>Task Details</h3>
+        <button
+          id="taskDetailClose"
+          class="task-detail-close"
+          type="button"
+          aria-label="Close task details"
+        >
+          ×
+        </button>
+      </div>
+
+      <div class="task-detail-actions">
+        <button
+          type="button"
+          id="panelBigThreeBtn"
+          class="task-action-btn big-three-btn"
+          aria-label="Toggle Big 3 task"
+        >
+          <i
+            class="fa-regular fa-star"
+            style="color: rgba(237, 28, 28, 1)"
+            aria-hidden="true"
+          ></i>
+          <span>Big 3</span>
+        </button>
+        <button type="button" id="panelEditBtn" class="task-action-btn">
+          <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
+          <span>Edit</span>
+        </button>
+        <button type="button" id="panelDeleteBtn" class="task-action-btn">
+          <i class="fa-solid fa-eraser" aria-hidden="true"></i>
+          <span>Delete</span>
+        </button>
+      </div>
+
+      <div class="task-detail-content">
+        <p class="task-detail-label">Task Description</p>
+        <p id="panelTaskDescription" class="task-detail-value"></p>
+        <input
+          id="panelTaskDescriptionInput"
+          class="task-detail-input"
+          type="text"
+          hidden
+        />
+
+        <p class="task-detail-label">Due Date</p>
+        <p id="panelTaskDueDate" class="task-detail-value"></p>
+        <input
+          id="panelTaskDueDateInput"
+          class="task-detail-input"
+          type="date"
+          hidden
+        />
+
+        <p class="task-detail-label">Effort Level</p>
+        <p id="panelTaskEffort" class="task-detail-value"></p>
+        <div
+          id="panelTaskEffortInput"
+          class="effort-options task-detail-effort-options"
+          role="radiogroup"
+          aria-label="Edit effort level"
+          hidden
+        >
+          <label class="effort-option"
+            ><input type="radio" name="panelEffortLevel" value="1" />1</label
+          >
+          <label class="effort-option"
+            ><input type="radio" name="panelEffortLevel" value="2" />2</label
+          >
+          <label class="effort-option"
+            ><input type="radio" name="panelEffortLevel" value="3" />3</label
+          >
+          <label class="effort-option"
+            ><input type="radio" name="panelEffortLevel" value="4" />4</label
+          >
+          <label class="effort-option"
+            ><input type="radio" name="panelEffortLevel" value="5" />5</label
+          >
+        </div>
+
+        <label
+          class="task-detail-complete checkbox-container"
+          aria-label="Mark task complete from details panel"
+        >
+          <input type="checkbox" id="panelTaskComplete" />
+          <span class="checkmark"></span>
+          <span class="task-detail-complete-text">Mark as complete</span>
+        </label>
+      </div>
+    </aside>
+    <div
+      id="task-detail-backdrop"
+      class="task-detail-backdrop"
+      aria-hidden="true"
+    ></div>
   </body>
 </html>

--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -85,6 +85,10 @@
         <header class="calendar-header">
           <h1 id="calendarMonthTitle" class="calendar-month-title">Month YYYY</h1>
           <div class="calendar-controls" aria-label="Month navigation">
+            <button id="calendarNewTaskBtn" class="calendar-nav-btn calendar-new-task-btn" type="button" aria-label="Create new task">
+              <i class="fa-solid fa-plus" aria-hidden="true"></i>
+              <span>New Task</span>
+            </button>
             <button id="calendarPrevBtn" class="calendar-nav-btn" type="button" aria-label="Previous month">
               <i class="fa-solid fa-chevron-left" aria-hidden="true"></i>
             </button>
@@ -110,6 +114,60 @@
         <div id="calendarGrid" class="calendar-grid" role="grid" aria-label="Calendar days"></div>
       </section>
     </main>
+
+    <div id="calendarTaskComposerOverlay" class="calendar-task-composer-overlay" hidden>
+      <div id="create-task-widget" class="sticky-note blue thumbtack calendar-task-composer">
+        <form
+          id="taskForm"
+          class="paper-form create-task-form-grid"
+          data-auto-close-on-submit="true"
+        >
+          <div class="paper-field task-field">
+            <label for="taskDescription">Task</label>
+            <input
+              id="taskDescription"
+              type="text"
+              name="description"
+              placeholder="What do you need to do?"
+              required
+            />
+          </div>
+
+          <div class="paper-field due-field">
+            <label for="dueDate">Due Date</label>
+            <input id="dueDate" type="date" name="dueDate" />
+          </div>
+
+          <div class="paper-field effort-field">
+            <label>Effort Level (1–5)</label>
+            <div class="effort-options" role="radiogroup" aria-label="Effort level">
+              <label class="effort-option">
+                <input type="radio" name="effortLevel" value="1" required />
+                1
+              </label>
+              <label class="effort-option">
+                <input type="radio" name="effortLevel" value="2" />
+                2
+              </label>
+              <label class="effort-option">
+                <input type="radio" name="effortLevel" value="3" checked />
+                3
+              </label>
+              <label class="effort-option">
+                <input type="radio" name="effortLevel" value="4" />
+                4
+              </label>
+              <label class="effort-option">
+                <input type="radio" name="effortLevel" value="5" />
+                5
+              </label>
+            </div>
+          </div>
+
+          <button id="submitBtn" class="paper-button" type="submit">Pin it!</button>
+        </form>
+      </div>
+    </div>
 
     <div
       id="toast"

--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -116,7 +116,7 @@
     </main>
 
     <div id="calendarTaskComposerOverlay" class="calendar-task-composer-overlay" hidden>
-      <div id="create-task-widget" class="sticky-note blue thumbtack calendar-task-composer">
+      <div id="create-task-widget" class="sticky-note blue tape calendar-task-composer">
         <form
           id="taskForm"
           class="paper-form create-task-form-grid"

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -563,6 +563,8 @@
   gap: 7px;
   font-family: "Itim", serif;
   font-size: 18px;
+  background: #e3f2fd;
+  color: #2f5f86;
 }
 
 .calendar-weekdays {
@@ -698,6 +700,29 @@
   width: min(530px, 94vw);
   max-height: min(90vh, 760px);
   overflow-y: auto;
+}
+
+#create-task-widget.calendar-task-composer .create-task-form-grid {
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "task"
+    "due"
+    "effort"
+    "submit";
+}
+
+#create-task-widget.calendar-task-composer .task-field,
+#create-task-widget.calendar-task-composer .due-field,
+#create-task-widget.calendar-task-composer .effort-field {
+  margin-bottom: 0;
+  margin-left: 0;
+}
+
+#create-task-widget.calendar-task-composer #submitBtn {
+  justify-self: center;
+  align-self: center;
+  margin-top: 4px;
+  width: clamp(150px, 62%, 230px);
 }
 
 .calendar-due-note-overlay {

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -726,6 +726,35 @@
   line-height: 1.2;
 }
 
+.calendar-due-task-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 10px;
+}
+
+.calendar-due-task-check {
+  width: 18px;
+  height: 18px;
+  margin-top: 3px;
+}
+
+.calendar-due-task-trigger {
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 0;
+  font-family: "Itim", serif;
+  color: #3c2318;
+  font-size: clamp(18px, 2vw, 24px);
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.calendar-due-task-trigger:hover {
+  text-decoration: underline;
+}
+
 .calendar-due-note-close {
   position: absolute;
   top: 8px;

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -699,7 +699,7 @@
 .calendar-task-composer {
   width: min(530px, 94vw);
   max-height: min(90vh, 760px);
-  overflow-y: auto;
+  overflow: visible;
 }
 
 #create-task-widget.calendar-task-composer .create-task-form-grid {

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -569,6 +569,10 @@
   color: #4f3023;
 }
 
+.weekday-short {
+  display: none;
+}
+
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
@@ -594,6 +598,12 @@
 
 .calendar-day.has-due-task {
   background: #f7dfe8;
+  cursor: pointer;
+}
+
+.calendar-day.has-due-task:focus-visible {
+  outline: 3px solid #c83939;
+  outline-offset: 2px;
 }
 
 .calendar-day::before {
@@ -642,15 +652,93 @@
 
 
 
-.calendar-day.calendar-note-leaving {
+.calendar-day.calendar-note-leaving,
+.calendar-due-note.calendar-note-leaving {
   animation: calendar-note-leave 300ms ease-in forwards;
   animation-delay: var(--note-stagger, 0ms);
   pointer-events: none;
 }
 
-.calendar-day.calendar-note-entering {
+.calendar-day.calendar-note-entering,
+.calendar-due-note.calendar-note-entering {
   animation: calendar-note-enter 360ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
   animation-delay: var(--note-stagger, 0ms);
+}
+
+.calendar-due-note-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(33, 20, 15, 0.34);
+  z-index: 1100;
+  padding: 20px;
+}
+
+.calendar-due-note-overlay.is-open {
+  display: flex;
+}
+
+.calendar-due-note {
+  position: relative;
+  width: min(520px, 92vw);
+  min-height: 260px;
+  background: #f7dfe8;
+  border-radius: 4px;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.24);
+  padding: 24px 24px 20px;
+  transform: rotate(-1deg);
+}
+
+.calendar-due-note::before {
+  content: "";
+  position: absolute;
+  top: -11px;
+  left: 50%;
+  transform: translateX(-50%) rotate(3deg);
+  width: 68px;
+  height: 18px;
+  background: rgba(245, 229, 197, 0.85);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+}
+
+.calendar-due-note-title {
+  margin: 0 28px 12px 0;
+  font-family: "Itim", serif;
+  color: #4f3023;
+  font-size: clamp(26px, 3vw, 34px);
+}
+
+.calendar-due-note-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+  max-height: min(45vh, 320px);
+  overflow-y: auto;
+}
+
+.calendar-due-note-list li {
+  font-family: "Itim", serif;
+  color: #3c2318;
+  font-size: clamp(18px, 2vw, 24px);
+  line-height: 1.2;
+}
+
+.calendar-due-note-close {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  width: 34px;
+  height: 34px;
+  border: none;
+  border-radius: 50%;
+  background: #fff8ea;
+  color: #6b4a35;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
 }
 
 @keyframes calendar-note-leave {
@@ -685,6 +773,14 @@
 @media (max-width: 760px) {
   .calendar-weekdays span {
     font-size: 10px;
+  }
+
+  .weekday-full {
+    display: none;
+  }
+
+  .weekday-short {
+    display: inline;
   }
 
   .calendar-day,

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -553,6 +553,18 @@
   font-size: 18px;
 }
 
+.calendar-new-task-btn {
+  width: auto;
+  min-width: 118px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-family: "Itim", serif;
+  font-size: 18px;
+}
+
 .calendar-weekdays {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
@@ -653,16 +665,39 @@
 
 
 .calendar-day.calendar-note-leaving,
-.calendar-due-note.calendar-note-leaving {
+.calendar-due-note.calendar-note-leaving,
+.calendar-task-composer.calendar-note-leaving {
   animation: calendar-note-leave 300ms ease-in forwards;
   animation-delay: var(--note-stagger, 0ms);
   pointer-events: none;
 }
 
 .calendar-day.calendar-note-entering,
-.calendar-due-note.calendar-note-entering {
+.calendar-due-note.calendar-note-entering,
+.calendar-task-composer.calendar-note-entering {
   animation: calendar-note-enter 360ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
   animation-delay: var(--note-stagger, 0ms);
+}
+
+.calendar-task-composer-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(33, 20, 15, 0.34);
+  z-index: 1080;
+  padding: 20px;
+}
+
+.calendar-task-composer-overlay.is-open {
+  display: flex;
+}
+
+.calendar-task-composer {
+  width: min(530px, 94vw);
+  max-height: min(90vh, 760px);
+  overflow-y: auto;
 }
 
 .calendar-due-note-overlay {
@@ -785,6 +820,15 @@
 @media (max-width: 760px) {
   .calendar-weekdays span {
     font-size: 10px;
+  }
+
+  .calendar-new-task-btn span {
+    display: none;
+  }
+
+  .calendar-new-task-btn {
+    min-width: 44px;
+    padding: 0;
   }
 
   .weekday-full {

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -727,32 +727,15 @@
 }
 
 .calendar-due-task-item {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: start;
-  gap: 10px;
-}
-
-.calendar-due-task-check {
-  width: 18px;
-  height: 18px;
-  margin-top: 3px;
+  margin-bottom: 6px;
 }
 
 .calendar-due-task-trigger {
-  border: none;
-  background: transparent;
-  text-align: left;
-  padding: 0;
-  font-family: "Itim", serif;
-  color: #3c2318;
-  font-size: clamp(18px, 2vw, 24px);
-  line-height: 1.2;
-  cursor: pointer;
+  width: 100%;
 }
 
 .calendar-due-task-trigger:hover {
-  text-decoration: underline;
+  color: #8B3A2E;
 }
 
 .calendar-due-note-close {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2529,6 +2529,38 @@ function initCalendarPage() {
   let visibleDate = new Date(todayYear, todayMonth, 1);
   let isTransitioning = false;
   let dueDateLookup = new Set();
+  let dueTasksByDate = new Map();
+  let isDueNoteTransitioning = false;
+
+  const dueNoteOverlay = document.createElement("div");
+  dueNoteOverlay.className = "calendar-due-note-overlay";
+  dueNoteOverlay.setAttribute("hidden", "hidden");
+
+  const dueNote = document.createElement("section");
+  dueNote.className = "calendar-due-note";
+  dueNote.setAttribute("role", "dialog");
+  dueNote.setAttribute("aria-modal", "true");
+  dueNote.setAttribute("aria-labelledby", "calendarDueNoteTitle");
+
+  const dueNoteCloseBtn = document.createElement("button");
+  dueNoteCloseBtn.className = "calendar-due-note-close";
+  dueNoteCloseBtn.type = "button";
+  dueNoteCloseBtn.setAttribute("aria-label", "Close due tasks list");
+  dueNoteCloseBtn.textContent = "×";
+
+  const dueNoteTitle = document.createElement("h2");
+  dueNoteTitle.id = "calendarDueNoteTitle";
+  dueNoteTitle.className = "calendar-due-note-title";
+  dueNoteTitle.textContent = "Due tasks";
+
+  const dueNoteList = document.createElement("ul");
+  dueNoteList.className = "calendar-due-note-list";
+
+  dueNote.appendChild(dueNoteCloseBtn);
+  dueNote.appendChild(dueNoteTitle);
+  dueNote.appendChild(dueNoteList);
+  dueNoteOverlay.appendChild(dueNote);
+  document.body.appendChild(dueNoteOverlay);
 
 
   const toLocalDateKey = (value) => {
@@ -2564,12 +2596,19 @@ function initCalendarPage() {
       const tasks = await response.json();
       if (!Array.isArray(tasks)) return;
 
-      dueDateLookup = new Set(
-        tasks
-          .filter((task) => task?.status === "active")
-          .map((task) => toLocalDateKey(task?.dueDate))
-          .filter(Boolean),
-      );
+      const activeTasks = tasks.filter((task) => task?.status === "active");
+      const dueTaskPairs = activeTasks
+        .map((task) => ({ key: toLocalDateKey(task?.dueDate), task }))
+        .filter((entry) => entry.key);
+
+      dueDateLookup = new Set(dueTaskPairs.map((entry) => entry.key));
+
+      dueTasksByDate = dueTaskPairs.reduce((lookup, entry) => {
+        const existing = lookup.get(entry.key) || [];
+        existing.push(entry.task);
+        lookup.set(entry.key, existing);
+        return lookup;
+      }, new Map());
     } catch (error) {
       console.error("Unable to load calendar due-date highlights:", error);
     }
@@ -2593,6 +2632,47 @@ function initCalendarPage() {
       element.addEventListener("animationend", finish, { once: true });
       window.setTimeout(finish, fallbackMs);
     });
+
+  const closeDueTasksNote = async () => {
+    if (isDueNoteTransitioning || dueNoteOverlay.hasAttribute("hidden")) return;
+
+    isDueNoteTransitioning = true;
+    dueNote.classList.remove("calendar-note-entering");
+    dueNote.classList.add("calendar-note-leaving");
+    await waitForAnimation(dueNote, 320);
+
+    dueNote.classList.remove("calendar-note-leaving");
+    dueNoteOverlay.setAttribute("hidden", "hidden");
+    dueNoteOverlay.classList.remove("is-open");
+    isDueNoteTransitioning = false;
+  };
+
+  const openDueTasksNote = async (dateKey, dayLabel) => {
+    if (isDueNoteTransitioning) return;
+
+    const dueTasks = dueTasksByDate.get(dateKey);
+    if (!Array.isArray(dueTasks) || !dueTasks.length) return;
+
+    dueNoteTitle.textContent = `Due tasks for ${dayLabel}`;
+    dueNoteList.innerHTML = "";
+
+    dueTasks.forEach((task) => {
+      const listItem = document.createElement("li");
+      listItem.textContent = task?.task || task?.name || "Untitled task";
+      dueNoteList.appendChild(listItem);
+    });
+
+    dueNoteOverlay.removeAttribute("hidden");
+    dueNoteOverlay.classList.add("is-open");
+
+    dueNote.classList.remove("calendar-note-leaving");
+    dueNote.classList.remove("calendar-note-entering");
+
+    requestAnimationFrame(() => {
+      dueNote.classList.add("calendar-note-entering");
+      window.setTimeout(() => dueNoteCloseBtn.focus(), 50);
+    });
+  };
 
   const renderCalendar = ({ animateIn = false } = {}) => {
     const year = visibleDate.getFullYear();
@@ -2623,6 +2703,26 @@ function initCalendarPage() {
       const visibleDateKey = buildVisibleDateKey(year, month, day);
       if (dueDateLookup.has(visibleDateKey)) {
         dayNote.classList.add("has-due-task");
+        dayNote.tabIndex = 0;
+        dayNote.setAttribute("aria-haspopup", "dialog");
+        dayNote.setAttribute("aria-label", `${monthTitle.textContent} ${day}, ${dueTasksByDate.get(visibleDateKey)?.length || 0} tasks due`);
+
+        const dayLabel = new Date(year, month, day).toLocaleDateString("en-US", {
+          month: "long",
+          day: "numeric",
+          year: "numeric",
+        });
+
+        dayNote.addEventListener("click", () => {
+          openDueTasksNote(visibleDateKey, dayLabel);
+        });
+
+        dayNote.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            openDueTasksNote(visibleDateKey, dayLabel);
+          }
+        });
       }
 
       if (animateIn) {
@@ -2683,6 +2783,22 @@ function initCalendarPage() {
 
   todayBtn.addEventListener("click", () => {
     transitionToMonth(new Date(todayYear, todayMonth, 1), { focusToday: true });
+  });
+
+  dueNoteCloseBtn.addEventListener("click", () => {
+    closeDueTasksNote();
+  });
+
+  dueNoteOverlay.addEventListener("click", (event) => {
+    if (event.target === dueNoteOverlay) {
+      closeDueTasksNote();
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      closeDueTasksNote();
+    }
   });
 
   loadDueDateHighlights().finally(() => {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2531,6 +2531,7 @@ function initCalendarPage() {
   let dueDateLookup = new Set();
   let dueTasksByDate = new Map();
   let isDueNoteTransitioning = false;
+  let pendingDueNoteReturn = null;
 
   const dueNoteOverlay = document.createElement("div");
   dueNoteOverlay.className = "calendar-due-note-overlay";
@@ -2789,6 +2790,7 @@ function initCalendarPage() {
       });
 
       descriptionButton.addEventListener("click", async () => {
+        pendingDueNoteReturn = { dateKey, dayLabel };
         await closeDueTasksNote();
         openTaskDetailPanel(task, handlers);
       });
@@ -2807,6 +2809,17 @@ function initCalendarPage() {
       dueNote.classList.add("calendar-note-entering");
       window.setTimeout(() => dueNoteCloseBtn.focus(), 50);
     });
+  };
+
+  const reopenDueNoteFromDetailPanelClose = () => {
+    if (!pendingDueNoteReturn) return;
+
+    const detailPanel = document.getElementById("task-detail-panel");
+    if (detailPanel?.classList.contains("is-open")) return;
+
+    const { dateKey, dayLabel } = pendingDueNoteReturn;
+    pendingDueNoteReturn = null;
+    openDueTasksNote(dateKey, dayLabel);
   };
 
   const renderCalendar = ({ animateIn = false } = {}) => {
@@ -2934,6 +2947,25 @@ function initCalendarPage() {
     if (event.key === "Escape") {
       closeDueTasksNote();
     }
+  });
+
+  const taskDetailCloseButton = document.getElementById("taskDetailClose");
+  const taskDetailBackdrop = document.getElementById("task-detail-backdrop");
+  const taskDetailPanel = document.getElementById("task-detail-panel");
+
+  taskDetailCloseButton?.addEventListener("click", () => {
+    window.setTimeout(reopenDueNoteFromDetailPanelClose, 0);
+  });
+
+  taskDetailBackdrop?.addEventListener("click", () => {
+    window.setTimeout(reopenDueNoteFromDetailPanelClose, 0);
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape" || !pendingDueNoteReturn) return;
+    if (!taskDetailPanel?.classList.contains("is-open")) return;
+
+    window.setTimeout(reopenDueNoteFromDetailPanelClose, 0);
   });
 
   loadDueDateHighlights().finally(() => {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2518,6 +2518,10 @@ function initCalendarPage() {
   const prevBtn = document.getElementById("calendarPrevBtn");
   const nextBtn = document.getElementById("calendarNextBtn");
   const todayBtn = document.getElementById("calendarTodayBtn");
+  const newTaskBtn = document.getElementById("calendarNewTaskBtn");
+  const taskComposerOverlay = document.getElementById("calendarTaskComposerOverlay");
+  const taskComposer = taskComposerOverlay?.querySelector(".calendar-task-composer");
+  const taskComposerForm = document.getElementById("taskForm");
 
   if (!calendarGrid || !monthTitle || !prevBtn || !nextBtn || !todayBtn) return;
 
@@ -2532,6 +2536,7 @@ function initCalendarPage() {
   let dueTasksByDate = new Map();
   let isDueNoteTransitioning = false;
   let pendingDueNoteReturn = null;
+  let isTaskComposerTransitioning = false;
 
   const dueNoteOverlay = document.createElement("div");
   dueNoteOverlay.className = "calendar-due-note-overlay";
@@ -2822,6 +2827,36 @@ function initCalendarPage() {
     openDueTasksNote(dateKey, dayLabel);
   };
 
+  const closeTaskComposer = async () => {
+    if (!taskComposerOverlay || !taskComposer || isTaskComposerTransitioning) return;
+    if (taskComposerOverlay.hasAttribute("hidden")) return;
+
+    isTaskComposerTransitioning = true;
+    taskComposer.classList.remove("calendar-note-entering");
+    taskComposer.classList.add("calendar-note-leaving");
+    await waitForAnimation(taskComposer, 320);
+
+    taskComposer.classList.remove("calendar-note-leaving");
+    taskComposerOverlay.setAttribute("hidden", "hidden");
+    taskComposerOverlay.classList.remove("is-open");
+    isTaskComposerTransitioning = false;
+  };
+
+  const openTaskComposer = () => {
+    if (!taskComposerOverlay || !taskComposer || isTaskComposerTransitioning) return;
+
+    taskComposerOverlay.removeAttribute("hidden");
+    taskComposerOverlay.classList.add("is-open");
+    taskComposer.classList.remove("calendar-note-leaving");
+    taskComposer.classList.remove("calendar-note-entering");
+
+    requestAnimationFrame(() => {
+      taskComposer.classList.add("calendar-note-entering");
+      const firstField = taskComposerForm?.querySelector("#taskDescription");
+      firstField?.focus();
+    });
+  };
+
   const renderCalendar = ({ animateIn = false } = {}) => {
     const year = visibleDate.getFullYear();
     const month = visibleDate.getMonth();
@@ -2933,6 +2968,10 @@ function initCalendarPage() {
     transitionToMonth(new Date(todayYear, todayMonth, 1), { focusToday: true });
   });
 
+  newTaskBtn?.addEventListener("click", () => {
+    openTaskComposer();
+  });
+
   dueNoteCloseBtn.addEventListener("click", () => {
     closeDueTasksNote();
   });
@@ -2946,7 +2985,19 @@ function initCalendarPage() {
   document.addEventListener("keydown", (event) => {
     if (event.key === "Escape") {
       closeDueTasksNote();
+      closeTaskComposer();
     }
+  });
+
+  taskComposerOverlay?.addEventListener("click", (event) => {
+    if (event.target === taskComposerOverlay) {
+      closeTaskComposer();
+    }
+  });
+
+  taskComposerForm?.addEventListener("task:created", async () => {
+    await closeTaskComposer();
+    await refreshCalendarDueData();
   });
 
   const taskDetailCloseButton = document.getElementById("taskDetailClose");
@@ -3245,6 +3296,10 @@ const submit = async function (event) {
       // Clear input fields after successful submission
       taskInput.value = "";
       dateInput.value = "";
+      const parentForm = taskInput.closest("form");
+      parentForm?.dispatchEvent(
+        new CustomEvent("task:created", { bubbles: true }),
+      );
       return;
     }
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2647,6 +2647,102 @@ function initCalendarPage() {
     isDueNoteTransitioning = false;
   };
 
+  const refreshCalendarDueData = async () => {
+    await loadDueDateHighlights();
+    renderCalendar();
+  };
+
+  const buildCalendarTaskPanelHandlers = (task, syncCheckboxState) => {
+    const setTaskCompletion = async (isCompleted) => {
+      const updated = await updateTaskCompletionStatus(
+        task,
+        isCompleted,
+        null,
+        null,
+      );
+
+      if (!updated) return false;
+
+      syncCheckboxState?.(isCompleted);
+      await refreshCalendarDueData();
+      return true;
+    };
+
+    const saveTaskEdits = async (updates) => {
+      const updateResponse = await apiFetch(`/tasks/${task._id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updates),
+      });
+
+      const updateData = await parseApiResponse(updateResponse);
+      if (!updateResponse.ok) {
+        Toast.show({
+          message: updateData.error || "Error updating task",
+          type: "error",
+          duration: 3200,
+        });
+        return null;
+      }
+
+      task.description = updateData.description ?? task.description;
+      task.dueDate = updateData.dueDate ?? task.dueDate;
+      task.effortLevel = updateData.effortLevel ?? task.effortLevel;
+      await refreshCalendarDueData();
+      Toast.show({
+        message: "Task Updated",
+        type: "success",
+        duration: 2000,
+      });
+      return updateData;
+    };
+
+    const deleteTask = async () => {
+      const confirmDelete = confirm(
+        "Are you sure you want to delete this task?",
+      );
+      if (!confirmDelete) return;
+
+      const deleteResponse = await apiFetch(`/tasks/${task._id}`, {
+        method: "DELETE",
+      });
+
+      if (deleteResponse.ok) {
+        Toast.show({
+          message: "Task deleted",
+          type: "success",
+          duration: 2000,
+        });
+        await refreshCalendarDueData();
+        closeTaskDetailPanel();
+      } else {
+        Toast.show({
+          message: "Could not delete task",
+          type: "error",
+          duration: 3000,
+        });
+      }
+    };
+
+    return {
+      saveTaskEdits,
+      deleteTask,
+      toggleComplete: async () => {
+        const panelTaskComplete = document.getElementById("panelTaskComplete");
+        if (!panelTaskComplete) return;
+
+        panelTaskComplete.disabled = true;
+        const isCompleted = panelTaskComplete.checked;
+        const updated = await setTaskCompletion(isCompleted);
+
+        if (!updated) {
+          panelTaskComplete.checked = !isCompleted;
+        }
+        panelTaskComplete.disabled = false;
+      },
+    };
+  };
+
   const openDueTasksNote = async (dateKey, dayLabel) => {
     if (isDueNoteTransitioning) return;
 
@@ -2658,7 +2754,46 @@ function initCalendarPage() {
 
     dueTasks.forEach((task) => {
       const listItem = document.createElement("li");
-      listItem.textContent = task?.task || task?.name || "Untitled task";
+      listItem.className = "calendar-due-task-item";
+
+      const completeInput = document.createElement("input");
+      completeInput.type = "checkbox";
+      completeInput.className = "calendar-due-task-check";
+      completeInput.checked = task.status === "completed";
+      completeInput.setAttribute("aria-label", `Mark ${task.description || "task"} complete`);
+
+      const descriptionButton = document.createElement("button");
+      descriptionButton.type = "button";
+      descriptionButton.className = "calendar-due-task-trigger";
+      descriptionButton.textContent = task.description || "Untitled task";
+      descriptionButton.title = "Open task details";
+
+      const handlers = buildCalendarTaskPanelHandlers(task, (isCompleted) => {
+        completeInput.checked = isCompleted;
+      });
+
+      completeInput.addEventListener("click", (event) => {
+        event.stopPropagation();
+      });
+
+      completeInput.addEventListener("change", async () => {
+        completeInput.disabled = true;
+        const nextValue = completeInput.checked;
+        const updated = await updateTaskCompletionStatus(task, nextValue, null, null);
+        if (!updated) {
+          completeInput.checked = !nextValue;
+        } else {
+          await refreshCalendarDueData();
+        }
+        completeInput.disabled = false;
+      });
+
+      descriptionButton.addEventListener("click", async () => {
+        await closeDueTasksNote();
+        openTaskDetailPanel(task, handlers);
+      });
+
+      listItem.append(completeInput, descriptionButton);
       dueNoteList.appendChild(listItem);
     });
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2754,17 +2754,17 @@ function initCalendarPage() {
 
     dueTasks.forEach((task) => {
       const listItem = document.createElement("li");
-      listItem.className = "calendar-due-task-item";
+      listItem.className = "calendar-due-task-item big-three-item";
 
       const completeInput = document.createElement("input");
       completeInput.type = "checkbox";
-      completeInput.className = "calendar-due-task-check";
+      completeInput.className = "task-check big-three-check";
       completeInput.checked = task.status === "completed";
       completeInput.setAttribute("aria-label", `Mark ${task.description || "task"} complete`);
 
       const descriptionButton = document.createElement("button");
       descriptionButton.type = "button";
-      descriptionButton.className = "calendar-due-task-trigger";
+      descriptionButton.className = "calendar-due-task-trigger big-three-details-trigger";
       descriptionButton.textContent = task.description || "Untitled task";
       descriptionButton.title = "Open task details";
 


### PR DESCRIPTION
### Motivation

- Improve the calendar's responsiveness by showing short weekday labels on small screens while keeping full names on larger viewports.
- Surface tasks that are due on calendar days and allow users to view a focused, accessible list of due tasks for a day.

### Description

- Replace static weekday text in `public/calendar-page.html` with nested spans for full and short labels and toggle visibility via `.weekday-full` and `.weekday-short` CSS rules.
- Add styles in `public/css/stickies.css` for responsive weekday labels and introduce a full UI for the due-tasks modal including `.calendar-due-note-overlay`, `.calendar-due-note`, and related element styles and animations.
- Update `public/js/main.js` to build a `dueTasksByDate` lookup in `loadDueDateHighlights`, create DOM elements for the due-tasks overlay, and add `openDueTasksNote` and `closeDueTasksNote` behavior with animation handling via `waitForAnimation`.
- Make calendar day cells with due tasks interactive and keyboard-accessible by adding `tabIndex`, `aria-haspopup`, enhanced `aria-label`s, and click/keyboard handlers in `renderCalendar` to open the overlay, plus global listeners to close the overlay on backdrop click or `Escape` press.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ce1fd2688326be5a5e9347e11018)