### PR TITLE
Add Calendar Focus button, polish calendar UX, improve clear-completed feedback, and make Google OAuth callback origin dynamic

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -85,6 +85,10 @@
         <header class="calendar-header">
           <h1 id="calendarMonthTitle" class="calendar-month-title">Month YYYY</h1>
           <div class="calendar-controls" aria-label="Month navigation">
+            <button id="calendarFocusBtn" class="calendar-nav-btn calendar-focus-btn" type="button" aria-label="Open focus page">
+              <i class="fa-solid fa-lock" aria-hidden="true"></i>
+              <span>Focus</span>
+            </button>
             <button id="calendarNewTaskBtn" class="calendar-nav-btn calendar-new-task-btn" type="button" aria-label="Create new task">
               <i class="fa-solid fa-plus" aria-hidden="true"></i>
               <span>New Task</span>

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -601,6 +601,11 @@
   display: none;
 }
 
+.weekday-full,
+.weekday-short {
+  font-weight: 700;
+}
+
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -866,6 +866,17 @@
 }
 
 @media (max-width: 760px) {
+  .calendar-header {
+    flex-direction: column-reverse;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .calendar-controls {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
   .calendar-weekdays span {
     font-size: 10px;
   }

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -872,14 +872,18 @@
 
 @media (max-width: 760px) {
   .calendar-header {
-    flex-direction: column-reverse;
-    align-items: stretch;
+    flex-direction: column;
+    align-items: center;
     gap: 10px;
+  }
+
+  .calendar-month-title {
+    text-align: center;
   }
 
   .calendar-controls {
     width: 100%;
-    justify-content: flex-end;
+    justify-content: center;
   }
 
   .calendar-weekdays span {

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -553,6 +553,20 @@
   font-size: 18px;
 }
 
+.calendar-focus-btn {
+  width: auto;
+  min-width: 100px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-family: "Itim", serif;
+  font-size: 18px;
+  background: #ffd6e7;
+  color: #8b2f5d;
+}
+
 .calendar-new-task-btn {
   width: auto;
   min-width: 118px;
@@ -608,6 +622,7 @@
   flex-direction: column;
   align-items: flex-start;
   aspect-ratio: 1 / 1;
+  transition: transform 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
 }
 
 .calendar-day.has-due-task {
@@ -618,6 +633,14 @@
 .calendar-day.has-due-task:focus-visible {
   outline: 3px solid #c83939;
   outline-offset: 2px;
+}
+
+@media (min-width: 761px) and (hover: hover) and (pointer: fine) {
+  .calendar-day.has-due-task:hover {
+    background: #f4cddd;
+    transform: translateY(-2px) rotate(-0.3deg);
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.24);
+  }
 }
 
 .calendar-day::before {
@@ -847,10 +870,12 @@
     font-size: 10px;
   }
 
+  .calendar-focus-btn span,
   .calendar-new-task-btn span {
     display: none;
   }
 
+  .calendar-focus-btn,
   .calendar-new-task-btn {
     min-width: 44px;
     padding: 0;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2681,6 +2681,7 @@ function initCalendarPage() {
   const prevBtn = document.getElementById("calendarPrevBtn");
   const nextBtn = document.getElementById("calendarNextBtn");
   const todayBtn = document.getElementById("calendarTodayBtn");
+  const focusBtn = document.getElementById("calendarFocusBtn");
   const newTaskBtn = document.getElementById("calendarNewTaskBtn");
   const taskComposerOverlay = document.getElementById("calendarTaskComposerOverlay");
   const taskComposer = taskComposerOverlay?.querySelector(".calendar-task-composer");
@@ -3133,6 +3134,10 @@ function initCalendarPage() {
     transitionToMonth(new Date(todayYear, todayMonth, 1), { focusToday: true });
   });
 
+  focusBtn?.addEventListener("click", () => {
+    window.location.href = "/focus-page.html";
+  });
+
   newTaskBtn?.addEventListener("click", () => {
     openTaskComposer();
   });
@@ -3380,17 +3385,15 @@ async function clearCompletedTasks() {
       (result) => result.status === "fulfilled" && result.value.ok,
     ).length;
 
-    if (deletedCount === completedTasks.length) {
+    if (deletedCount > 0) {
+      const taskLabel = deletedCount === 1 ? "task" : "tasks";
+      const partialFailure = deletedCount < completedTasks.length;
       Toast.show({
-        message: "Cleared completed tasks",
+        message: partialFailure
+          ? `Cleared ${deletedCount} completed ${taskLabel}. Some could not be deleted.`
+          : `Successfully cleared ${deletedCount} completed ${taskLabel}.`,
         type: "success",
-        duration: 2500,
-      });
-    } else if (deletedCount > 0) {
-      Toast.show({
-        message: `Cleared ${deletedCount} completed tasks. Some could not be deleted.`,
-        type: "error",
-        duration: 3500,
+        duration: partialFailure ? 3500 : 2500,
       });
     } else {
       Toast.show({

--- a/server.js
+++ b/server.js
@@ -829,13 +829,19 @@ app.get("/auth/google", authRateLimiter, (req, res, next) => {
     return res.redirect("/login.html?error=google_unavailable");
   }
 
-  const canonicalOrigin = getCanonicalGoogleAuthOrigin();
   const requestOrigin = getRequestOrigin(req);
-  if (canonicalOrigin && requestOrigin && canonicalOrigin !== requestOrigin) {
-    return res.redirect(`${canonicalOrigin}/auth/google`);
+  const canonicalOrigin = getCanonicalGoogleAuthOrigin();
+  const callbackOrigin = requestOrigin || canonicalOrigin;
+  const callbackURL = callbackOrigin
+    ? `${callbackOrigin.replace(/\/$/, "")}/auth/google/callback`
+    : undefined;
+
+  const authOptions = { scope: ["profile", "email"] };
+  if (callbackURL) {
+    authOptions.callbackURL = callbackURL;
   }
 
-  passport.authenticate("google", { scope: ["profile", "email"] })(req, res, next);
+  passport.authenticate("google", authOptions)(req, res, next);
 });
 
 app.get("/auth/google/callback", authRateLimiter, (req, res) => {


### PR DESCRIPTION
### Motivation
- Provide a quick-access "Focus" action from the calendar UI so users can jump to the focus page. 
- Improve visual feedback and hover behavior for calendar days that have due tasks for a more tactile UX. 
- Make the user feedback for clearing completed tasks more informative and handle partial failures gracefully. 
- Ensure Google OAuth works reliably when the app is behind proxies or served from different request origins by deriving the callback URL dynamically. 

### Description
- Added a `Focus` button (`#calendarFocusBtn`) to `public/calendar-page.html` and wired it in `public/js/main.js` to navigate to `/focus-page.html`. 
- Introduced `.calendar-focus-btn` styles and added transitions and a hover effect for `.calendar-day.has-due-task` in `public/css/stickies.css`, plus responsive hiding of button labels on small screens. 
- Updated `clearCompletedTasks` in `public/js/main.js` to compute `deletedCount` and show success messages that indicate the number of deleted tasks and whether some deletions failed. 
- Reworked the Google OAuth entry route in `server.js` to construct a `callbackURL` from the incoming request origin (falling back to the canonical origin) and pass it via `authOptions` to `passport.authenticate`, removing the prior unconditional redirect logic. 

### Testing
- Ran the automated test suite via `npm test`, and it completed successfully. 
- Ran linting via `npm run lint`, which passed with no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f6a05ea483269615ce0fbb1d952b)