### PR TITLE
Add confirmation modals and UI polish (delete account, clear completed), calendar focus button, and Google OAuth callback fix

### DIFF
--- a/public/calendar-page.html
+++ b/public/calendar-page.html
@@ -85,6 +85,10 @@
         <header class="calendar-header">
           <h1 id="calendarMonthTitle" class="calendar-month-title">Month YYYY</h1>
           <div class="calendar-controls" aria-label="Month navigation">
+            <button id="calendarFocusBtn" class="calendar-nav-btn calendar-focus-btn" type="button" aria-label="Open focus page">
+              <i class="fa-solid fa-lock" aria-hidden="true"></i>
+              <span>Focus</span>
+            </button>
             <button id="calendarNewTaskBtn" class="calendar-nav-btn calendar-new-task-btn" type="button" aria-label="Create new task">
               <i class="fa-solid fa-plus" aria-hidden="true"></i>
               <span>New Task</span>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2206,23 +2206,101 @@ body.task-panel-open {
 }
 
 .profile-delete-confirm-note {
-  background: rgba(255, 255, 255, 0.45);
-  border: 2px dashed #b54f6a;
-  border-radius: 12px;
-  padding: 0.65rem 0.7rem;
+  position: relative;
+  width: min(520px, 92vw);
+  min-height: 260px;
+  background: #f7dfe8;
+  border-radius: 4px;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.24);
+  padding: 24px 24px 20px;
+  transform: rotate(-1deg);
+}
+
+.profile-delete-confirm-note::before {
+  content: "";
+  position: absolute;
+  top: -11px;
+  left: 50%;
+  transform: translateX(-50%) rotate(3deg);
+  width: 68px;
+  height: 18px;
+  background: rgba(245, 229, 197, 0.85);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+}
+
+.profile-delete-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  background: rgba(20, 12, 8, 0.36);
+  align-items: center;
+  justify-content: center;
+  z-index: 1305;
+  padding: 1rem;
+}
+
+.profile-delete-confirm-overlay.is-open {
+  display: flex;
+}
+
+.profile-delete-confirm-title {
+  margin: 0 28px 12px 0;
+  color: #4f3023;
+  font-family: "Itim", serif;
+  font-size: clamp(26px, 3vw, 34px);
 }
 
 .profile-delete-confirm-note p {
   margin: 0;
-  color: #5f2337;
-  font-size: 0.96rem;
+  color: #3c2318;
+  font-family: "Itim", serif;
+  font-size: clamp(18px, 2vw, 24px);
+  line-height: 1.2;
 }
 
 .profile-delete-confirm-actions {
-  margin-top: 0.6rem;
+  margin-top: 1.1rem;
   display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
+  justify-content: center;
+  gap: 0.8rem;
+}
+
+.profile-delete-confirm-note.profile-note-leaving {
+  animation: profile-delete-note-leave 300ms ease-in forwards;
+  pointer-events: none;
+}
+
+.profile-delete-confirm-note.profile-note-entering {
+  animation: profile-delete-note-enter 360ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
+}
+
+@keyframes profile-delete-note-leave {
+  0% {
+    transform: translateX(0) translateY(0) rotate(-1deg);
+    opacity: 1;
+  }
+  35% {
+    transform: translateX(8px) translateY(-10px) rotate(1deg);
+  }
+  100% {
+    transform: translateX(110vw) translateY(-15px) rotate(3deg);
+    opacity: 0;
+  }
+}
+
+@keyframes profile-delete-note-enter {
+  0% {
+    transform: translateX(110vw) translateY(-15px) rotate(3deg);
+    opacity: 0;
+  }
+  70% {
+    transform: translateX(-6px) translateY(0) rotate(-0.8deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(0) translateY(0) rotate(-1deg);
+    opacity: 1;
+  }
 }
 
 .profile-cancel-delete-btn {
@@ -2445,13 +2523,15 @@ body.task-panel-open {
   }
 
   .feedback-photo-btn {
-    width: 100%;
+    width: min(100%, 240px);
     justify-content: center;
+    margin-inline: auto;
   }
 
   #feedbackSubmitBtn {
-    width: 100%;
+    width: min(100%, 240px);
     text-align: center;
+    align-self: center;
   }
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2486,6 +2486,7 @@ body.task-panel-open {
   background: #ffe6d9;
   color: #612a27;
   font-family: "Quantico", sans-serif;
+  font-size: 0.85rem;
   font-weight: 700;
   cursor: pointer;
 }

--- a/public/css/stickies.css
+++ b/public/css/stickies.css
@@ -553,6 +553,20 @@
   font-size: 18px;
 }
 
+.calendar-focus-btn {
+  width: auto;
+  min-width: 100px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-family: "Itim", serif;
+  font-size: 18px;
+  background: #ffd6e7;
+  color: #8b2f5d;
+}
+
 .calendar-new-task-btn {
   width: auto;
   min-width: 118px;
@@ -587,6 +601,11 @@
   display: none;
 }
 
+.weekday-full,
+.weekday-short {
+  font-weight: 700;
+}
+
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
@@ -608,6 +627,7 @@
   flex-direction: column;
   align-items: flex-start;
   aspect-ratio: 1 / 1;
+  transition: transform 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
 }
 
 .calendar-day.has-due-task {
@@ -618,6 +638,14 @@
 .calendar-day.has-due-task:focus-visible {
   outline: 3px solid #c83939;
   outline-offset: 2px;
+}
+
+@media (min-width: 761px) and (hover: hover) and (pointer: fine) {
+  .calendar-day.has-due-task:hover {
+    background: #f4cddd;
+    transform: translateY(-2px) rotate(-0.3deg);
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.24);
+  }
 }
 
 .calendar-day::before {
@@ -843,14 +871,31 @@
 }
 
 @media (max-width: 760px) {
+  .calendar-header {
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .calendar-month-title {
+    text-align: center;
+  }
+
+  .calendar-controls {
+    width: 100%;
+    justify-content: center;
+  }
+
   .calendar-weekdays span {
     font-size: 10px;
   }
 
+  .calendar-focus-btn span,
   .calendar-new-task-btn span {
     display: none;
   }
 
+  .calendar-focus-btn,
   .calendar-new-task-btn {
     min-width: 44px;
     padding: 0;

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -303,6 +303,44 @@
     <script defer src="/_vercel/insights/script.js"></script>
 
     <div
+      id="clearCompletedConfirmOverlay"
+      class="profile-delete-confirm-overlay"
+      hidden
+    >
+      <section
+        id="clearCompletedConfirmNote"
+        class="profile-delete-confirm-note"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="clearCompletedConfirmTitle"
+      >
+        <h2 id="clearCompletedConfirmTitle" class="profile-delete-confirm-title">
+          Clear Completed Tasks
+        </h2>
+        <p>
+          This will remove all completed tasks from your list. This cannot be
+          undone.
+        </p>
+        <div class="profile-delete-confirm-actions">
+          <button
+            id="clearCompletedCancelBtn"
+            class="paper-button profile-cancel-delete-btn"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            id="clearCompletedConfirmBtn"
+            class="paper-button profile-confirm-delete-btn"
+            type="button"
+          >
+            Yes, Clear
+          </button>
+        </div>
+      </section>
+    </div>
+
+    <div
       id="toast"
       class="toast toast--default"
       role="status"

--- a/public/feedback-page.html
+++ b/public/feedback-page.html
@@ -139,9 +139,7 @@
             aria-live="polite"
           ></ul>
 
-          <button id="feedbackSubmitBtn" type="submit">
-            Send bug report
-          </button>
+          <button id="feedbackSubmitBtn" type="submit">Send</button>
         </form>
       </section>
     </main>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1940,7 +1940,7 @@ function getProfilePanelMarkup(panelKey, user = null) {
           <input id="feedbackPhotoInput" name="feedbackPhotos" type="file" accept="image/*" multiple hidden />
           <textarea id="feedbackMessage" name="feedbackMessage" maxlength="2000" rows="6" placeholder="Steps to reproduce, expected result, and what you saw." required></textarea>
           <ul id="feedbackAttachmentList" class="feedback-attachment-list" aria-live="polite"></ul>
-          <button id="feedbackSubmitBtn" type="submit">Send bug report</button>
+          <button id="feedbackSubmitBtn" type="submit">Send</button>
         </form>
       </section>
     `;
@@ -2027,11 +2027,13 @@ function getProfilePanelMarkup(panelKey, user = null) {
 
 function initDeleteAccountFlow() {
   const deleteBtn = document.getElementById("profileDeleteAccountBtn");
+  const confirmOverlay = document.getElementById("profileDeleteConfirmOverlay");
   const confirmNote = document.getElementById("profileDeleteConfirmNote");
   const cancelBtn = document.getElementById("profileCancelDeleteBtn");
   const confirmBtn = document.getElementById("profileConfirmDeleteBtn");
 
-  if (!deleteBtn || !confirmNote || !cancelBtn || !confirmBtn) return;
+  if (!deleteBtn || !confirmOverlay || !confirmNote || !cancelBtn || !confirmBtn) return;
+  let isTransitioning = false;
 
   const setBusyState = (isBusy) => {
     confirmBtn.disabled = isBusy;
@@ -2040,14 +2042,69 @@ function initDeleteAccountFlow() {
     confirmBtn.textContent = isBusy ? "Deleting..." : "Yes, Delete";
   };
 
-  deleteBtn.addEventListener("click", () => {
-    confirmNote.hidden = false;
+  const waitForAnimation = (element, timeoutMs = 360) =>
+    new Promise((resolve) => {
+      if (!element) {
+        resolve();
+        return;
+      }
+
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        element.removeEventListener("animationend", onAnimationEnd);
+        resolve();
+      };
+
+      const onAnimationEnd = () => finish();
+      element.addEventListener("animationend", onAnimationEnd, { once: true });
+      window.setTimeout(finish, timeoutMs);
+    });
+
+  const openConfirmDialog = () => {
+    if (isTransitioning || !confirmOverlay.hasAttribute("hidden")) return;
+    confirmOverlay.removeAttribute("hidden");
+    confirmOverlay.classList.add("is-open");
+    confirmNote.classList.remove("profile-note-leaving");
+    confirmNote.classList.remove("profile-note-entering");
+    window.requestAnimationFrame(() => {
+      confirmNote.classList.add("profile-note-entering");
+    });
     deleteBtn.hidden = true;
+  };
+
+  const closeConfirmDialog = async () => {
+    if (confirmBtn.disabled || isTransitioning || confirmOverlay.hasAttribute("hidden")) return;
+    isTransitioning = true;
+    confirmNote.classList.remove("profile-note-entering");
+    confirmNote.classList.add("profile-note-leaving");
+    await waitForAnimation(confirmNote, 320);
+    confirmNote.classList.remove("profile-note-leaving");
+    confirmOverlay.classList.remove("is-open");
+    confirmOverlay.setAttribute("hidden", "hidden");
+    deleteBtn.hidden = false;
+    isTransitioning = false;
+  };
+
+  deleteBtn.addEventListener("click", () => {
+    openConfirmDialog();
   });
 
-  cancelBtn.addEventListener("click", () => {
-    confirmNote.hidden = true;
-    deleteBtn.hidden = false;
+  cancelBtn.addEventListener("click", async () => {
+    await closeConfirmDialog();
+  });
+
+  confirmOverlay.addEventListener("click", async (event) => {
+    if (event.target === confirmOverlay) {
+      await closeConfirmDialog();
+    }
+  });
+
+  document.addEventListener("keydown", async (event) => {
+    if (event.key === "Escape" && !confirmOverlay.hasAttribute("hidden")) {
+      await closeConfirmDialog();
+    }
   });
 
   confirmBtn.addEventListener("click", async () => {
@@ -2123,9 +2180,16 @@ function initProfileBoardNav() {
       } else {
         deleteAccountContainer.remove();
         const deleteBtn = document.getElementById("profileDeleteAccountBtn");
-        const confirmNote = document.getElementById("profileDeleteConfirmNote");
+        const confirmOverlay = document.getElementById("profileDeleteConfirmOverlay");
         if (deleteBtn) deleteBtn.hidden = false;
-        if (confirmNote) confirmNote.hidden = true;
+        if (confirmOverlay) {
+          confirmOverlay.setAttribute("hidden", "hidden");
+          confirmOverlay.classList.remove("is-open");
+        }
+        const confirmNote = document.getElementById("profileDeleteConfirmNote");
+        if (confirmNote) {
+          confirmNote.classList.remove("profile-note-entering", "profile-note-leaving");
+        }
       }
     }
   };
@@ -2659,7 +2723,7 @@ document.addEventListener("DOMContentLoaded", () => {
     "clear-completed-tasks-btn",
   );
   if (clearCompletedButton) {
-    clearCompletedButton.addEventListener("click", clearCompletedTasks);
+    initClearCompletedTaskConfirmDialog();
   }
 
   bindDashboardTaskFilterTabs();
@@ -2681,6 +2745,7 @@ function initCalendarPage() {
   const prevBtn = document.getElementById("calendarPrevBtn");
   const nextBtn = document.getElementById("calendarNextBtn");
   const todayBtn = document.getElementById("calendarTodayBtn");
+  const focusBtn = document.getElementById("calendarFocusBtn");
   const newTaskBtn = document.getElementById("calendarNewTaskBtn");
   const taskComposerOverlay = document.getElementById("calendarTaskComposerOverlay");
   const taskComposer = taskComposerOverlay?.querySelector(".calendar-task-composer");
@@ -3133,6 +3198,10 @@ function initCalendarPage() {
     transitionToMonth(new Date(todayYear, todayMonth, 1), { focusToday: true });
   });
 
+  focusBtn?.addEventListener("click", () => {
+    window.location.href = "/focus-page.html";
+  });
+
   newTaskBtn?.addEventListener("click", () => {
     openTaskComposer();
   });
@@ -3380,17 +3449,15 @@ async function clearCompletedTasks() {
       (result) => result.status === "fulfilled" && result.value.ok,
     ).length;
 
-    if (deletedCount === completedTasks.length) {
+    if (deletedCount > 0) {
+      const taskLabel = deletedCount === 1 ? "task" : "tasks";
+      const partialFailure = deletedCount < completedTasks.length;
       Toast.show({
-        message: "Cleared completed tasks",
+        message: partialFailure
+          ? `Cleared ${deletedCount} completed ${taskLabel}. Some could not be deleted.`
+          : `Successfully cleared ${deletedCount} completed ${taskLabel}.`,
         type: "success",
-        duration: 2500,
-      });
-    } else if (deletedCount > 0) {
-      Toast.show({
-        message: `Cleared ${deletedCount} completed tasks. Some could not be deleted.`,
-        type: "error",
-        duration: 3500,
+        duration: partialFailure ? 3500 : 2500,
       });
     } else {
       Toast.show({
@@ -3413,6 +3480,106 @@ async function clearCompletedTasks() {
       clearCompletedButton.disabled = false;
     }
   }
+}
+
+function initClearCompletedTaskConfirmDialog() {
+  const clearCompletedButton = document.getElementById(
+    "clear-completed-tasks-btn",
+  );
+  const confirmOverlay = document.getElementById("clearCompletedConfirmOverlay");
+  const confirmNote = document.getElementById("clearCompletedConfirmNote");
+  const cancelBtn = document.getElementById("clearCompletedCancelBtn");
+  const confirmBtn = document.getElementById("clearCompletedConfirmBtn");
+
+  if (
+    !clearCompletedButton ||
+    !confirmOverlay ||
+    !confirmNote ||
+    !cancelBtn ||
+    !confirmBtn
+  ) return;
+
+  let isTransitioning = false;
+
+  const waitForAnimation = (element, timeoutMs = 360) =>
+    new Promise((resolve) => {
+      if (!element) {
+        resolve();
+        return;
+      }
+
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        element.removeEventListener("animationend", onAnimationEnd);
+        resolve();
+      };
+
+      const onAnimationEnd = () => finish();
+      element.addEventListener("animationend", onAnimationEnd, { once: true });
+      window.setTimeout(finish, timeoutMs);
+    });
+
+  const openDialog = () => {
+    if (isTransitioning || !confirmOverlay.hasAttribute("hidden")) return;
+    confirmOverlay.removeAttribute("hidden");
+    confirmOverlay.classList.add("is-open");
+    confirmNote.classList.remove("profile-note-leaving");
+    confirmNote.classList.remove("profile-note-entering");
+    window.requestAnimationFrame(() => {
+      confirmNote.classList.add("profile-note-entering");
+    });
+  };
+
+  const closeDialog = async () => {
+    if (isTransitioning || confirmOverlay.hasAttribute("hidden")) return;
+    isTransitioning = true;
+    confirmNote.classList.remove("profile-note-entering");
+    confirmNote.classList.add("profile-note-leaving");
+    await waitForAnimation(confirmNote, 320);
+    confirmNote.classList.remove("profile-note-leaving");
+    confirmOverlay.classList.remove("is-open");
+    confirmOverlay.setAttribute("hidden", "hidden");
+    isTransitioning = false;
+  };
+
+  clearCompletedButton.addEventListener("click", () => {
+    openDialog();
+  });
+
+  cancelBtn.addEventListener("click", async () => {
+    if (confirmBtn.disabled) return;
+    await closeDialog();
+  });
+
+  confirmOverlay.addEventListener("click", async (event) => {
+    if (event.target !== confirmOverlay || confirmBtn.disabled) return;
+    await closeDialog();
+  });
+
+  document.addEventListener("keydown", async (event) => {
+    if (event.key !== "Escape") return;
+    if (confirmOverlay.hasAttribute("hidden") || confirmBtn.disabled) return;
+    await closeDialog();
+  });
+
+  confirmBtn.addEventListener("click", async () => {
+    confirmBtn.disabled = true;
+    cancelBtn.disabled = true;
+    clearCompletedButton.disabled = true;
+    confirmBtn.textContent = "Clearing...";
+
+    try {
+      await clearCompletedTasks();
+      await closeDialog();
+    } finally {
+      confirmBtn.disabled = false;
+      cancelBtn.disabled = false;
+      confirmBtn.textContent = "Yes, Clear";
+      updateTaskList(dashboardTaskState.allTasks);
+    }
+  });
 }
 
 // Function to submit a task (User must be logged in)

--- a/public/profile-page.html
+++ b/public/profile-page.html
@@ -150,23 +150,27 @@
           <button id="profileDeleteAccountBtn" class="paper-button profile-delete-account-btn" type="button">
             Delete Account
           </button>
-          <div id="profileDeleteConfirmNote" class="profile-delete-confirm-note" hidden>
-            <p>
-              This will permanently delete your account and all related data.
-              This action cannot be undone.
-            </p>
-            <div class="profile-delete-confirm-actions">
-              <button id="profileCancelDeleteBtn" class="paper-button profile-cancel-delete-btn" type="button">
-                Cancel
-              </button>
-              <button id="profileConfirmDeleteBtn" class="paper-button profile-confirm-delete-btn" type="button">
-                Yes, Delete
-              </button>
-            </div>
-          </div>
         </div>
       </section>
     </main>
+
+    <div id="profileDeleteConfirmOverlay" class="profile-delete-confirm-overlay" hidden>
+      <section id="profileDeleteConfirmNote" class="profile-delete-confirm-note" role="dialog" aria-modal="true" aria-labelledby="profileDeleteConfirmTitle">
+        <h2 id="profileDeleteConfirmTitle" class="profile-delete-confirm-title">Delete Account</h2>
+        <p>
+          This will permanently delete your account and all related data.
+          This action cannot be undone.
+        </p>
+        <div class="profile-delete-confirm-actions">
+          <button id="profileCancelDeleteBtn" class="paper-button profile-cancel-delete-btn" type="button">
+            Cancel
+          </button>
+          <button id="profileConfirmDeleteBtn" class="paper-button profile-confirm-delete-btn" type="button">
+            Yes, Delete
+          </button>
+        </div>
+      </section>
+    </div>
 
     <div
       id="toast"

--- a/server.js
+++ b/server.js
@@ -829,13 +829,19 @@ app.get("/auth/google", authRateLimiter, (req, res, next) => {
     return res.redirect("/login.html?error=google_unavailable");
   }
 
-  const canonicalOrigin = getCanonicalGoogleAuthOrigin();
   const requestOrigin = getRequestOrigin(req);
-  if (canonicalOrigin && requestOrigin && canonicalOrigin !== requestOrigin) {
-    return res.redirect(`${canonicalOrigin}/auth/google`);
+  const canonicalOrigin = getCanonicalGoogleAuthOrigin();
+  const callbackOrigin = requestOrigin || canonicalOrigin;
+  const callbackURL = callbackOrigin
+    ? `${callbackOrigin.replace(/\/$/, "")}/auth/google/callback`
+    : undefined;
+
+  const authOptions = { scope: ["profile", "email"] };
+  if (callbackURL) {
+    authOptions.callbackURL = callbackURL;
   }
 
-  passport.authenticate("google", { scope: ["profile", "email"] })(req, res, next);
+  passport.authenticate("google", authOptions)(req, res, next);
 });
 
 app.get("/auth/google/callback", authRateLimiter, (req, res) => {


### PR DESCRIPTION
### Motivation
- Improve safety and UX for destructive actions by converting inline confirmations into accessible modal overlays with animations and keyboard/overlay dismissal.  
- Provide a quick entry to Focus mode from the calendar and polish calendar UI interactions and responsive behavior.  
- Fix Google OAuth callback handling to use the request origin when available so SSO works behind proxies and custom callback hosts.  

### Description
- Introduce modal overlay markup for account deletion and a new confirmation dialog for clearing completed tasks in `profile-page.html` and `dashboard.html`, and wire them up in `public/js/main.js`.  
- Refactor `initDeleteAccountFlow` to use an overlay with animated enter/leave states, `waitForAnimation`, keyboard (Escape) handling, backdrop click dismissal, and transition locking, and add `initClearCompletedTaskConfirmDialog` to provide the same behavior for clearing completed tasks.  
- Update `clearCompletedTasks` to present clearer success/failure messages including partial-failure counts and to call `fetchTasks`/`updateTaskList` after operations.  
- Add a calendar Focus button in `public/calendar-page.html` and handle navigation to `/focus-page.html` from `initCalendarPage`, plus new `.calendar-focus-btn` styles and calendar UI improvements in `public/css/stickies.css` (hover transforms, responsive layout tweaks, weekday font weights).  
- Restyle the profile delete note and overlay and add enter/leave animations in `public/css/main.css`, and shorten the feedback button label (`Send bug report` → `Send`) in feedback markup and `getProfilePanelMarkup`.  
- Improve Google OAuth flow in `server.js` by constructing a `callbackURL` from the request origin (falling back to canonical origin) and passing it to `passport.authenticate` instead of forcing a redirect to the canonical origin.  

### Testing
- Ran lint and build locally with `npm run lint` and `npm run build`, which completed successfully.  
- Performed automated smoke/flow checks by invoking the app start script and exercising the delete-account and clear-completed flows programmatically (modal open/close, confirm/cancel) and observed expected network calls and UI state changes.  
- No automated unit tests were added or modified by this change; existing test suite and static checks remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f6a05ea483269615ce0fbb1d952b)