### PR TITLE
Potential fix for code scanning alert no. 43: Uncontrolled data used in path expression

### DIFF
--- a/server.js
+++ b/server.js
@@ -1765,8 +1765,15 @@ app.get("/auth-status", (req, res) => {
 
 
 // Serve other static files dynamically
+const PUBLIC_ROOT = path.resolve(__dirname, "public");
+
 app.get("/:file", (req, res) => {
-    const filename = path.join(__dirname, "public", req.params.file);
+    const filename = path.resolve(PUBLIC_ROOT, req.params.file);
+
+    if (filename !== PUBLIC_ROOT && !filename.startsWith(PUBLIC_ROOT + path.sep)) {
+        return res.status(403).send("403 Error: Forbidden");
+    }
+
     if (fs.existsSync(filename)) {
         res.type(mime.getType(filename));
         res.sendFile(filename);

--- a/server.js
+++ b/server.js
@@ -1768,7 +1768,14 @@ app.get("/auth-status", (req, res) => {
 const PUBLIC_ROOT = path.resolve(__dirname, "public");
 
 app.get("/:file", (req, res) => {
-    const filename = path.resolve(PUBLIC_ROOT, req.params.file);
+    const requestedFile = req.params.file;
+
+    // Allow only simple safe filenames (no path separators or special traversal characters)
+    if (!/^[A-Za-z0-9._-]+$/.test(requestedFile)) {
+        return res.status(400).send("400 Error: Invalid file name");
+    }
+
+    const filename = path.resolve(PUBLIC_ROOT, requestedFile);
 
     if (filename !== PUBLIC_ROOT && !filename.startsWith(PUBLIC_ROOT + path.sep)) {
         return res.status(403).send("403 Error: Forbidden");


### PR DESCRIPTION
Potential fix for [https://github.com/Ajohno/Stick-A-Pin/security/code-scanning/43](https://github.com/Ajohno/Stick-A-Pin/security/code-scanning/43)

Use a safe-root validation approach for the dynamic file route:

1. Define a fixed root directory for public files (`path.resolve(__dirname, "public")`).
2. Resolve the user-supplied filename against that root (`path.resolve(PUBLIC_ROOT, req.params.file)`), which normalizes traversal segments.
3. Enforce containment by checking the resolved path starts with `PUBLIC_ROOT + path.sep` (or equals `PUBLIC_ROOT`).
4. If validation fails, return 403.
5. Keep existing behavior for existing/missing files (send file if exists, 404 otherwise).

This change is localized to `server.js` around the `app.get("/:file", ...)` handler and does not change intended functionality for valid files in `public`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
