### PR TITLE
Soft-delete tasks, snapshot focus descriptions, and server reflection stats

### DIFF
--- a/config/models/focusSession.js
+++ b/config/models/focusSession.js
@@ -8,6 +8,7 @@ const FocusSessionSchema = new mongoose.Schema({
 
     userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
     taskId: { type: mongoose.Schema.Types.ObjectId, ref: "Task", required: true },
+    taskDescriptionSnapshot: { type: String, trim: true, default: "" },
 
     startedAt: { type: Date, required: true },
     endedAt: { type: Date, default: null },

--- a/config/models/task.js
+++ b/config/models/task.js
@@ -18,11 +18,15 @@ const TaskSchema = new mongoose.Schema(
 
     status: { type: String, enum: ["active", "completed"], default: "active" },
     completedAt: { type: Date, default: null },
+    deletedAt: { type: Date, default: null },
 
     // Route logic enforces the per-user limit of three selected priority tasks.
     isBigThree: { type: Boolean, default: false },
   },
   { timestamps: true }
 );
+
+TaskSchema.index({ userId: 1, deletedAt: 1, isBigThree: 1 });
+TaskSchema.index({ userId: 1, status: 1, completedAt: 1 });
 
 module.exports = mongoose.model("Task", TaskSchema);

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1196,46 +1196,17 @@ function formatDailyFocusDuration(durationMs) {
   return `${hours} hr ${minutes} min`;
 }
 
-function getCompletedTaskCountToday(tasks = []) {
-  const now = new Date();
-  const dayStart = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-  ).getTime();
-  const nextDay = dayStart + 24 * 60 * 60 * 1000;
-
-  if (!Array.isArray(tasks)) return 0;
-
-  return tasks.reduce((count, task) => {
-    if (task?.status !== "completed") return count;
-    const completedAt = new Date(task?.completedAt || 0).getTime();
-    if (
-      Number.isFinite(completedAt) &&
-      completedAt >= dayStart &&
-      completedAt < nextDay
-    ) {
-      return count + 1;
-    }
-    return count;
-  }, 0);
-}
-
-function getCompletedTaskCountInRange(tasks = [], startMs = 0, endMs = 0) {
-  if (!Array.isArray(tasks)) return 0;
-
-  return tasks.reduce((count, task) => {
-    if (task?.status !== "completed") return count;
-    const completedAt = new Date(task?.completedAt || 0).getTime();
-    if (
-      Number.isFinite(completedAt) &&
-      completedAt >= startMs &&
-      completedAt < endMs
-    ) {
-      return count + 1;
-    }
-    return count;
-  }, 0);
+async function fetchReflectionStats(from, to) {
+  const query = new URLSearchParams({ from, to }).toString();
+  const response = await apiFetch(`/reflection-stats?${query}`, {
+    credentials: "include",
+    cache: "no-store",
+  });
+  const data = await parseApiResponse(response);
+  if (!response.ok) {
+    throw new Error(data?.error || "Could not load reflection statistics");
+  }
+  return data;
 }
 
 function renderDailyReflectionStats({
@@ -1305,51 +1276,13 @@ async function refreshDailyReflectionStats() {
 
   try {
     const { startIso, endIso } = getTodayDateRangeIso();
-    const focusQuery = new URLSearchParams({ from: startIso, to: endIso }).toString();
-
-    const [sessionsResponse, tasksResponse] = await Promise.all([
-      apiFetch(`/focus-sessions?${focusQuery}`, {
-        credentials: "include",
-        cache: "no-store",
-      }),
-      apiFetch("/tasks", {
-        credentials: "include",
-        cache: "no-store",
-      }),
-    ]);
-
-    const [sessionsData, tasksData] = await Promise.all([
-      parseApiResponse(sessionsResponse),
-      parseApiResponse(tasksResponse),
-    ]);
-
-    if (!sessionsResponse.ok) {
-      throw new Error(sessionsData?.error || "Could not load focus sessions");
-    }
-    if (!tasksResponse.ok) {
-      throw new Error(tasksData?.error || "Could not load tasks");
-    }
-
-    const sessions = Array.isArray(sessionsData) ? sessionsData : [];
-    const tasks = Array.isArray(tasksData) ? tasksData : [];
-
-    const focusedTaskIds = new Set(
-      sessions
-        .map((session) => session?.taskId)
-        .filter((taskId) => taskId !== null && taskId !== undefined)
-        .map((taskId) => String(taskId)),
-    );
-
-    const totalFocusMs = sessions.reduce(
-      (sum, session) => sum + computeSessionDurationMs(session),
-      0,
-    );
+    const stats = await fetchReflectionStats(startIso, endIso);
 
     renderDailyReflectionStats({
       dateLabel: todayLabel,
-      tasksFocused: focusedTaskIds.size,
-      focusTimeLabel: formatDailyFocusDuration(totalFocusMs),
-      tasksCompleted: getCompletedTaskCountToday(tasks),
+      tasksFocused: stats.tasksFocused,
+      focusTimeLabel: formatDailyFocusDuration(stats.totalFocusMs),
+      tasksCompleted: stats.tasksCompleted,
     });
   } catch (error) {
     console.error("Could not refresh daily reflection stats:", error);
@@ -1394,55 +1327,13 @@ async function refreshWeeklyReflectionStats() {
   });
 
   try {
-    const focusQuery = new URLSearchParams({ from: startIso, to: endIso }).toString();
-
-    const [sessionsResponse, tasksResponse] = await Promise.all([
-      apiFetch(`/focus-sessions?${focusQuery}`, {
-        credentials: "include",
-        cache: "no-store",
-      }),
-      apiFetch("/tasks", {
-        credentials: "include",
-        cache: "no-store",
-      }),
-    ]);
-
-    const [sessionsData, tasksData] = await Promise.all([
-      parseApiResponse(sessionsResponse),
-      parseApiResponse(tasksResponse),
-    ]);
-
-    if (!sessionsResponse.ok) {
-      throw new Error(sessionsData?.error || "Could not load focus sessions");
-    }
-    if (!tasksResponse.ok) {
-      throw new Error(tasksData?.error || "Could not load tasks");
-    }
-
-    const sessions = Array.isArray(sessionsData) ? sessionsData : [];
-    const tasks = Array.isArray(tasksData) ? tasksData : [];
-
-    const focusedTaskIds = new Set(
-      sessions
-        .map((session) => session?.taskId)
-        .filter((taskId) => taskId !== null && taskId !== undefined)
-        .map((taskId) => String(taskId)),
-    );
-
-    const totalFocusMs = sessions.reduce(
-      (sum, session) => sum + computeSessionDurationMs(session),
-      0,
-    );
+    const stats = await fetchReflectionStats(startIso, endIso);
 
     renderWeeklyReflectionStats({
       dateLabel: weekLabel,
-      tasksFocused: focusedTaskIds.size,
-      focusTimeLabel: formatDailyFocusDuration(totalFocusMs),
-      tasksCompleted: getCompletedTaskCountInRange(
-        tasks,
-        new Date(startIso).getTime(),
-        new Date(endIso).getTime(),
-      ),
+      tasksFocused: stats.tasksFocused,
+      focusTimeLabel: formatDailyFocusDuration(stats.totalFocusMs),
+      tasksCompleted: stats.tasksCompleted,
     });
   } catch (error) {
     console.error("Could not refresh weekly reflection stats:", error);

--- a/server.js
+++ b/server.js
@@ -1353,25 +1353,46 @@ function parseIsoDateTimeInput(value) {
   return date;
 }
 
-/** Flatten a populated or unpopulated session into the same client response shape. */
-function toFocusSessionResponse(session) {
+function visibleTaskFilter(userId, additionalFilters = {}) {
+  return { userId, deletedAt: null, ...additionalFilters };
+}
+
+function getFocusSessionTaskId(session) {
   const rawTask = session?.taskId;
-  const taskId = rawTask && typeof rawTask === "object" && rawTask._id
+  return rawTask && typeof rawTask === "object" && rawTask._id
     ? rawTask._id
     : rawTask;
-  const taskDescription = rawTask && typeof rawTask === "object" && rawTask.description
-    ? rawTask.description
-    : null;
+}
+
+/** Flatten a populated or unpopulated session into the same client response shape. */
+function toFocusSessionResponse(session, { resolvedTaskDescription = null } = {}) {
+  const taskId = getFocusSessionTaskId(session);
+  const snapshot = String(session?.taskDescriptionSnapshot || "").trim();
+  const populatedDescription = session?.taskId && typeof session.taskId === "object"
+    ? String(session.taskId.description || "").trim()
+    : "";
 
   return {
     _id: session._id,
     taskId,
-    taskDescription,
+    taskDescription: snapshot || String(resolvedTaskDescription || "").trim() || populatedDescription || null,
     startedAt: session.startedAt,
     endedAt: session.endedAt,
     durationMs: session.durationMs || 0,
     endedReason: session.endedReason
   };
+}
+
+function computeFocusSessionDurationMs(session, now = new Date()) {
+  const storedDuration = Number(session?.durationMs);
+  if (Number.isFinite(storedDuration) && storedDuration > 0) return storedDuration;
+
+  const startedAt = new Date(session?.startedAt).getTime();
+  const endedAt = session?.endedAt
+    ? new Date(session.endedAt).getTime()
+    : new Date(now).getTime();
+  const calculated = endedAt - startedAt;
+  return Number.isFinite(calculated) && calculated > 0 ? calculated : 0;
 }
 
 // Task CRUD APIs are logged-in user-data routes protected by explicit auth and rate-limit middleware.
@@ -1393,7 +1414,7 @@ app.post("/tasks", apiProbeLimiter, ensureAuthenticated, userApiLimiter, async (
     status: "active",
   });
 
-  const userTasks = await Task.find({ userId: req.user.id });
+  const userTasks = await Task.find(visibleTaskFilter(req.user.id));
   return res.json(userTasks);
 });
 
@@ -1401,7 +1422,7 @@ app.post("/tasks", apiProbeLimiter, ensureAuthenticated, userApiLimiter, async (
 // Gets tasks for the logged-in user
 app.get("/tasks", apiProbeLimiter, ensureAuthenticated, userApiLimiter, async (req, res) => {
     try {
-        const userTasks = await Task.find({ userId: req.user.id });
+        const userTasks = await Task.find(visibleTaskFilter(req.user.id));
         res.status(200).json(userTasks);
     } catch (err) {
         console.error("Error Fetching Tasks:", err);
@@ -1412,7 +1433,7 @@ app.get("/tasks", apiProbeLimiter, ensureAuthenticated, userApiLimiter, async (r
 // Route to update tasks in the MongoDB database
 app.put("/tasks/:taskId", apiProbeLimiter, ensureAuthenticated, userApiLimiter, async (req, res) => {
   try {
-    const task = await Task.findOne({ _id: req.params.taskId, userId: req.user.id });
+    const task = await Task.findOne(visibleTaskFilter(req.user.id, { _id: req.params.taskId }));
     if (!task) return res.status(404).json({ error: "Task not found" });
 
     // allow updates
@@ -1473,11 +1494,10 @@ app.put("/tasks/:taskId", apiProbeLimiter, ensureAuthenticated, userApiLimiter, 
 
       const nextIsBigThree = req.body.isBigThree;
       if (nextIsBigThree && !task.isBigThree) {
-        const existingBigThreeCount = await Task.countDocuments({
-          userId: req.user.id,
+        const existingBigThreeCount = await Task.countDocuments(visibleTaskFilter(req.user.id, {
           isBigThree: true,
           _id: { $ne: task._id }
-        });
+        }));
 
         if (existingBigThreeCount >= 3) {
           return res.status(400).json({ error: "You can only have 3 Big 3 tasks at once." });
@@ -1498,17 +1518,17 @@ app.put("/tasks/:taskId", apiProbeLimiter, ensureAuthenticated, userApiLimiter, 
 // Route to delete a task
 app.delete("/tasks/:taskId", apiProbeLimiter, ensureAuthenticated, userApiLimiter, async (req, res) => {
   try {
-    const deleted = await Task.findOneAndDelete({
-      _id: req.params.taskId,
-      userId: req.user.id, // important: only delete your own tasks
-    });
+    const deleted = await Task.findOneAndUpdate(
+      visibleTaskFilter(req.user.id, { _id: req.params.taskId }),
+      { $set: { deletedAt: new Date(), isBigThree: false } },
+      { new: true },
+    );
 
     if (!deleted) {
       return res.status(404).json({ error: "Task not found" });
     }
 
     return res.json({ message: "Task deleted successfully" });
-    fetchTasks(); // Refresh the task list on the client side
   } catch (err) {
     console.error("Error deleting task:", err);
     return res.status(500).json({ error: "Server error while deleting task" });
@@ -1526,7 +1546,7 @@ app.post("/focus-sessions/start", apiProbeLimiter, ensureAuthenticated, userApiL
       return res.status(400).json({ error: "Invalid taskId format" });
     }
 
-    const task = await Task.findOne({ _id: taskId, userId: req.user.id });
+    const task = await Task.findOne(visibleTaskFilter(req.user.id, { _id: taskId }));
     if (!task) {
       return res.status(404).json({ error: "Task not found" });
     }
@@ -1552,15 +1572,13 @@ app.post("/focus-sessions/start", apiProbeLimiter, ensureAuthenticated, userApiL
     const created = await FocusSession.create({
       userId: req.user.id,
       taskId: task._id,
+      taskDescriptionSnapshot: task.description,
       startedAt: now
     });
 
-    const session = await FocusSession.findById(created._id).populate({
-      path: "taskId",
-      select: "description"
-    });
-
-    return res.status(201).json(toFocusSessionResponse(session));
+    return res.status(201).json(toFocusSessionResponse(created, {
+      resolvedTaskDescription: task.description,
+    }));
   } catch (err) {
     console.error("Error starting focus session:", err);
     return res.status(500).json({ error: "Server error while starting focus session" });
@@ -1589,12 +1607,14 @@ app.post("/focus-sessions/stop", apiProbeLimiter, ensureAuthenticated, userApiLi
     openSession.endedReason = endedReason;
     await openSession.save();
 
-    const session = await FocusSession.findById(openSession._id).populate({
-      path: "taskId",
-      select: "description"
-    });
+    const task = await Task.findOne({
+      _id: getFocusSessionTaskId(openSession),
+      userId: req.user.id,
+    }).select("description");
 
-    return res.json(toFocusSessionResponse(session));
+    return res.json(toFocusSessionResponse(openSession, {
+      resolvedTaskDescription: task?.description,
+    }));
   } catch (err) {
     console.error("Error stopping focus session:", err);
     return res.status(500).json({ error: "Server error while stopping focus session" });
@@ -1624,14 +1644,58 @@ app.get("/focus-sessions", apiProbeLimiter, ensureAuthenticated, userApiLimiter,
       if (to) query.startedAt.$lt = to;
     }
 
-    const sessions = await FocusSession.find(query)
-      .sort({ startedAt: -1 })
-      .populate({ path: "taskId", select: "description" });
+    const sessions = await FocusSession.find(query).sort({ startedAt: -1 });
+    const taskIds = sessions.map(getFocusSessionTaskId).filter(Boolean);
+    const tasks = await Task.find({
+      _id: { $in: taskIds },
+      userId: req.user.id,
+    }).select("_id description").lean();
+    const descriptionsByTaskId = new Map(tasks.map((task) => [
+      String(task._id),
+      String(task.description || "").trim(),
+    ]));
 
-    return res.json(sessions.map((session) => toFocusSessionResponse(session)));
+    return res.json(sessions.map((session) => toFocusSessionResponse(session, {
+      resolvedTaskDescription: descriptionsByTaskId.get(String(getFocusSessionTaskId(session))),
+    })));
   } catch (err) {
     console.error("Error retrieving focus sessions:", err);
     return res.status(500).json({ error: "Server error while retrieving focus sessions" });
+  }
+});
+
+app.get("/reflection-stats", apiProbeLimiter, ensureAuthenticated, userApiLimiter, async (req, res) => {
+  try {
+    const from = parseIsoDateTimeInput(req.query.from);
+    const to = parseIsoDateTimeInput(req.query.to);
+    if (!from || !to || from >= to) {
+      return res.status(400).json({ error: "A valid from date earlier than to is required" });
+    }
+
+    const [tasksCompleted, sessions] = await Promise.all([
+      Task.countDocuments({
+        userId: req.user.id,
+        status: "completed",
+        completedAt: { $gte: from, $lt: to },
+      }),
+      FocusSession.find({
+        userId: req.user.id,
+        startedAt: { $gte: from, $lt: to },
+      }).select("taskId startedAt endedAt durationMs"),
+    ]);
+    const tasksFocused = new Set(
+      sessions.map(getFocusSessionTaskId).filter(Boolean).map(String),
+    ).size;
+    const now = new Date();
+    const totalFocusMs = sessions.reduce(
+      (total, session) => total + computeFocusSessionDurationMs(session, now),
+      0,
+    );
+
+    return res.json({ tasksCompleted, tasksFocused, totalFocusMs });
+  } catch (err) {
+    console.error("Error retrieving reflection statistics:", err);
+    return res.status(500).json({ error: "Server error while retrieving reflection statistics" });
   }
 });
 


### PR DESCRIPTION
### Motivation

- Preserve historical data when tasks are renamed or deleted by using soft deletion and immutable session snapshots so focus history and reflection totals remain stable.
- Ensure operational features (board, calendar, focus selector, edits) continue to hide deleted tasks while historical queries and emails still include soft-deleted completions.

### Description

- Added a nullable `deletedAt` field and two indexes to the Task model and added `taskDescriptionSnapshot` to FocusSession to record the task description at session start (`config/models/task.js`, `config/models/focusSession.js`).
- Introduced a reusable `visibleTaskFilter(userId, additionalFilters)` helper and applied it to task creation/listing, `GET /tasks`, `PUT /tasks/:taskId`, Big Three counting, and focus-session start lookups so soft-deleted tasks are excluded from operational flows (`server.js`).
- Replaced permanent deletion with an atomic soft-delete in `DELETE /tasks/:taskId` that sets `deletedAt` and clears `isBigThree`, preserves historical fields, and returns `404` when appropriate (`server.js`).
- Persisted the task description snapshot when starting a focus session and implemented a single serializer that uses the priority: snapshot → resolved current description → null; refactored focus-session read/stop flows to retain raw `taskId` values and resolve descriptions in a single batch including soft-deleted tasks (`server.js`).
- Added `/reflection-stats?from=<ISO>&to=<ISO>` API that returns server-calculated `tasksCompleted`, `tasksFocused`, and `totalFocusMs` (half-open ranges, includes soft-deleted completed tasks, and preserves client duration semantics) and added a server-side helper for session-duration calculation (`server.js`).
- Updated client reflection widgets to call the new `/reflection-stats` endpoint and removed client-side historical counting from `/tasks`, while preserving existing UI loading/error states and legacy fallbacks (`public/js/main.js`).

### Testing

- Ran static/syntax checks: `node --check server.js`, `node --check public/js/main.js`, `node --check config/models/task.js`, and `node --check config/models/focusSession.js`, and all checks passed.
- Ran repository sanity checks (`git diff --check`) with no new whitespace or merge errors reported and verified modified file diffs.
- Did not add automated endpoint tests because the repository has no test script or test harness that can run meaningful DB-backed API tests; `npm test` was not applicable.
- Manual verification checklist remains recommended (snapshot retention after rename/delete, inclusion of soft-deleted completed tasks in reflection totals, operational blocking of deleted tasks, Big Three slot release, email data) because those require a running DB and authenticated flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c8fd85b50832680ca5e23ed8599db)